### PR TITLE
fix: 알림 페이지 헤더 타입 에러 해결 #70

### DIFF
--- a/src/components/Notifications/Header/index.tsx
+++ b/src/components/Notifications/Header/index.tsx
@@ -41,7 +41,7 @@ const Header = ({ isSelecting, setIsSelecting, selectedList }: Props) => {
       <S.Title>알림</S.Title>
       <S.DeleteButton onClick={handleIsSelecting}>{isSelecting ? '선택완료' : '삭제'}</S.DeleteButton>
       {isModal && <CheckModal isOpen={isModal} handleClose={() => setIsModal(false)} handleConfirm={handleConfirm} />}
-      {isToast && <Toast setToast={setIsToast}>삭제가 완료되었습니다!</Toast>}
+      {isToast && <Toast setIsExist={setIsToast}>삭제가 완료되었습니다!</Toast>}
     </S.Wrapper>
   );
 };


### PR DESCRIPTION
## What is this PR?🔍

- 알림 페이지 헤더에서 사용하는 Toast 컴포넌트의 props 명을 `setToast`에서 `setIsExist`로 변경해 타입 에러 해결

<img width="983" alt="스크린샷 2023-06-10 오후 10 01 23" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/f4453585-d33a-4b44-a126-20932ff9b346">
