### PR TITLE
[Design]: 일부 페이지에서 깨지는 레이아웃 해결

### DIFF
--- a/src/components/Apply/Content/style.tsx
+++ b/src/components/Apply/Content/style.tsx
@@ -95,13 +95,16 @@ export const ApplyHeader = styled.div`
 `;
 
 export const ApplyItem = styled.li`
-  width: 730px;
-  height: 96px;
+  width: 100%;
   background-color: var(--color-white);
-  padding: 16px 24px 16px 24px;
+  padding: 16px 24px;
+
   display: flex;
   align-items: center;
-  gap: 35px;
+  gap: 20px;
+
+  box-shadow: 0px 0px 7px rgba(102, 109, 117, 0.1);
+  border-radius: 8px;
 
   .time {
     ${theme.font.ko.body1}
@@ -114,6 +117,11 @@ export const ApplyProfile = styled.div`
   display: flex;
   gap: 20px;
   align-items: center;
+
+  svg {
+    width: 64px;
+    height: 64px;
+  }
 
   span {
     font-weight: 700;
@@ -133,26 +141,23 @@ export const Contour = styled.div`
 `;
 
 export const Gender = styled.div`
-  ${theme.font.ko.button};
+  font-weight: 400;
+  font-size: 12px;
   color: var(--color-white);
   background-color: var(--color-primary-main);
   padding: 6px 8px 6px 8px;
   border-radius: 4px;
-  width: 41px;
-  height: 28px;
 `;
 
 export const ButtonGroup = styled.div`
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 5px;
+  gap: 16px;
 `;
 export const ApplyButton = styled.div`
-  width: 104px;
-  height: 44px;
   border-radius: 6px;
-  padding: 10px 24px 10px 24px;
+  padding: 10px 20px;
   background-color: var(--color-primary-main);
   ${theme.font.ko.body1}
   color: var(--color-white);
@@ -162,8 +167,6 @@ export const ApplyButton = styled.div`
 `;
 
 export const ChattingButton = styled.div`
-  width: 104px;
-  height: 44px;
   border-radius: 6px;
   padding: 10px 20px 10px 20px;
   background-color: var(--color-white);

--- a/src/components/Search/Header/style.tsx
+++ b/src/components/Search/Header/style.tsx
@@ -1,6 +1,7 @@
 import styled from 'styled-components';
 
 export const Wrapper = styled.header`
+  position: relative;
   width: 100%;
   height: 80px;
   padding: 16px 24px 16px 24px;
@@ -11,15 +12,15 @@ export const Wrapper = styled.header`
   background-color: var(--color-white);
 
   svg {
-    flex: 1.9;
+    position: absolute;
+    left: 24px;
+    width: 32px;
+    height: 32px;
     cursor: pointer;
   }
 
   span {
-    flex: 2.2;
     font-weight: 700;
     font-size: 24px;
-    line-height: 34px;
-    letter-spacing: -1%;
   }
 `;

--- a/src/components/Search/History/style.tsx
+++ b/src/components/Search/History/style.tsx
@@ -3,15 +3,23 @@ import styled from 'styled-components';
 export const Wrapper = styled.li`
   display: flex;
   justify-content: space-between;
-  width: 730px;
+  width: 100%;
   padding: 8px 8px 8px 20px;
   align-items: center;
+
+  & > svg {
+    cursor: pointer;
+  }
 `;
 
 export const SearchHistory = styled.div`
   display: flex;
   align-items: center;
   gap: 25px;
+
+  user-select: none;
+  cursor: pointer;
+
   span {
     font-size: 20px;
     font-weight: 500;

--- a/src/components/Search/Input/style.tsx
+++ b/src/components/Search/Input/style.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const SearchInput = styled.div`
-  width: 730px;
+  width: 100%;
   height: 48px;
   padding: 8px 8px 8px 20px;
   border-radius: 6px;


### PR DESCRIPTION
## What is this PR?🔍

- 검색 페이지와 신청목록 페이지의 너비를 수정해, 페이지 영역 밖으로 컨텐츠가 보이는 현상 해결

## 결과 화면

- 검색 페이지

  <table>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
    <tr>
      <td><img width="500" alt="검색 페이지 before" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/42003254-bcb7-42cf-ad26-e54e54a3bcac"></td>
      <td><img width="500" alt="검색 페이지 after" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/ff78609d-2fba-48e3-bfa7-021c2a84b1e6"></td>
    </tr>
  </table>

- 신청목록 페이지

  <table>
    <tr>
      <td>Before</td>
      <td>After</td>
    </tr>
    <tr>
      <td><img width="500" alt="신청목록 페이지 before" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/17df6f99-f5e9-4563-8c74-0efa6d4db800"></td>
      <td><img width="500" alt="신청목록 페이지 after" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/49f4a4c7-ce57-46bd-b301-1e4129ec6b43"></td>
    </tr>
  </table>

## 이슈

> 신청목록 페이지에서..
> 1.  받은 신청 탭은 되어 있지만, 요청한 신청 탭은 퍼블리싱 되어 있지 않음 (작업 필요)
> 2.  `함께하기` 버튼을 눌렀을 때 별도의 효과가 없음 (작업 필요)

디자인 수정용 브랜치에서 작업 하는 것보다 새로 브랜치를 파서 하는 게 나을 것 같아 디자인만 수정 했습니다.
— *추후 작업 예정.. (이번 스프린트 내)*



