### PR TITLE
[Feat]: 글쓰기 페이지에서  날짜와 시간을 설정하기 위한  BottomSheet - CalendarTime 컴포넌트 생성

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "babel-plugin-styled-components": "^2.0.7",
     "cross-env": "^7.0.3",
     "js-cookie": "^3.0.1",
+    "moment": "^2.29.4",
     "next": "13.2.1",
     "next-images": "^1.8.4",
     "react": "18.2.0",

--- a/src/assets/icon/top-arrow.svg
+++ b/src/assets/icon/top-arrow.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="11" viewBox="0 0 16 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.88 10.5467L8 4.44008L14.12 10.5467L16 8.66675L8 0.666748L0 8.66675L1.88 10.5467Z" fill="#68696B"/>
+</svg>

--- a/src/components/Common/BottomSheet/BottomSheetList/Calendar/index.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/Calendar/index.tsx
@@ -3,12 +3,12 @@ import * as S from './style';
 import CalendarIcon from '@assets/icon/calendar.svg';
 import BottomArrowIcon from '@assets/icon/bottom-arrow.svg';
 import { useBottomSheet } from '@hooks/common';
-import Calendar from 'react-calendar';
+import ReactCalendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
 
 type ValuePiece = Date | null;
 
-const Calandar = () => {
+const Calendar = () => {
   const { closeBottomSheet } = useBottomSheet();
   const [value, onChange] = useState<ValuePiece | [ValuePiece, ValuePiece]>(new Date());
 
@@ -17,16 +17,16 @@ const Calandar = () => {
   return (
     <S.BottomSheetContent>
       <S.BottomSheetHeader>
-        <span className="select_pitness">
+        <span className="select_fitness">
           <CalendarIcon />
           운동날짜
         </span>
         <BottomArrowIcon />
       </S.BottomSheetHeader>
       <S.Content>
-        <S.CalandarWrapper>
-          <Calendar onChange={onChange} value={value} />
-        </S.CalandarWrapper>
+        <S.CalendarWrapper>
+          <ReactCalendar onChange={onChange} value={value} />
+        </S.CalendarWrapper>
       </S.Content>
       <S.ButtonGroup>
         <S.CancelButton>취소</S.CancelButton>
@@ -36,4 +36,4 @@ const Calandar = () => {
   );
 };
 
-export default Calandar;
+export default Calendar;

--- a/src/components/Common/BottomSheet/BottomSheetList/Calendar/style.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/Calendar/style.tsx
@@ -24,7 +24,7 @@ export const BottomSheetHeader = styled.div`
   border-bottom: 1px solid var(--color-gray3);
   padding-bottom: 15px;
 
-  .select_pitness {
+  .select_fitness {
     font-weight: 700;
     font-size: 16px;
     line-height: 30px;
@@ -34,7 +34,7 @@ export const BottomSheetHeader = styled.div`
     gap: 15px;
   }
 
-  .register_pitness {
+  .register_fitness {
     display: flex;
     align-items: center;
     gap: 6px;
@@ -106,7 +106,7 @@ export const Button = styled.button`
   cursor: pointer;
 `;
 
-export const CalandarWrapper = styled.div`
+export const CalendarWrapper = styled.div`
   width: 100%;
   display: flex;
   font-family: 'Pretendard';

--- a/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/Time/index.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/Time/index.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import * as S from './style';
+
+type TimeProps = {
+  onChange: (time: string, isAM: boolean) => void;
+  amTime: string;
+  pmTime: string;
+};
+
+const Time = ({ onChange, amTime, pmTime }: TimeProps) => {
+  const times = ['12:00', '1:00', '2:00', '3:00', '4:00', '5:00', '6:00', '7:00', '8:00', '9:00', '10:00', '11:00'];
+  const [selectAMTime, setSelectAMTime] = useState('');
+  const [selectPMTime, setSelectPMTime] = useState('');
+
+  const handleSelectAM = (time: string) => {
+    setSelectAMTime(time);
+    setSelectPMTime('');
+    onChange(time, true); // true: 오전
+  };
+
+  const handleSelectPM = (time: string) => {
+    setSelectPMTime(time);
+    setSelectAMTime('');
+    onChange(time, false); // false: 오후
+  };
+
+  return (
+    <div>
+      <S.Wrapper>
+        <S.Subject>오전</S.Subject>
+        <S.TimesWrapper>
+          {times.map((time, idx) => (
+            <S.Time
+              key={idx}
+              onClick={() => handleSelectAM(time)}
+              isSelected={time === selectAMTime}
+              isCurrent={time === amTime} // 현재 선택된 오전 시간
+            >
+              {time}
+            </S.Time>
+          ))}
+        </S.TimesWrapper>
+      </S.Wrapper>
+      <S.Wrapper>
+        <S.Subject>오후</S.Subject>
+        <S.TimesWrapper>
+          {times.map((time, idx) => (
+            <S.Time
+              key={idx}
+              onClick={() => handleSelectPM(time)}
+              isSelected={time === selectPMTime}
+              isCurrent={time === pmTime} // 현재 선택된 오후 시간
+            >
+              {time}
+            </S.Time>
+          ))}
+        </S.TimesWrapper>
+      </S.Wrapper>
+    </div>
+  );
+};
+
+export default Time;

--- a/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/Time/style.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/Time/style.tsx
@@ -1,0 +1,50 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  text-align: center;
+  color: var(--color-gray8);
+`;
+
+export const Subject = styled.span`
+  font-weight: 700;
+`;
+
+export const TimesWrapper = styled.div`
+  width: 590px;
+  height: fit-content;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 16px;
+  margin-bottom: 24px;
+`;
+
+const getBackgroundColor = (isSelected: boolean, isCurrent: boolean): string => {
+  if (isSelected) {
+    return 'var(--color-primary-main)';
+  }
+  if (isCurrent) {
+    return 'var(--color-primary-light)';
+  }
+  return 'var(--color-white)';
+};
+
+const getTextColor = (isSelected: boolean, isCurrent: boolean): string =>
+  isSelected || isCurrent ? 'var(--color-white)' : 'var(--color-gray8)';
+// isSelected 와 isCurrent 중 하나라도 true 일 때 'var(--color-white)'
+// 둘 다 false 일 때 'var(--color-gray8)'
+
+export const Time = styled.div<{ isSelected: boolean; isCurrent: boolean }>`
+  width: 80px;
+  height: 54px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: 0px 0px 7px rgba(102, 109, 117, 0.1);
+  border-radius: 8px;
+  cursor: pointer;
+  font-weight: 400;
+  background-color: ${(props) => getBackgroundColor(props.isSelected, props.isCurrent)};
+  color: ${(props) => getTextColor(props.isSelected, props.isCurrent)};
+`;

--- a/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/index.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/index.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import * as S from './style';
+import CalendarIcon from '@assets/icon/calendar.svg';
+import ClockIcon from '@assets/icon/clock.svg';
+import BottomArrowIcon from '@assets/icon/bottom-arrow.svg';
+import TopArrowIcon from '@assets/icon/top-arrow.svg';
+import { useBottomSheet } from '@hooks/common';
+import ReactCalendar from 'react-calendar';
+import 'react-calendar/dist/Calendar.css';
+import Time from './Time';
+import moment from 'moment';
+
+type ValuePiece = Date | null;
+
+const CalendarTime = () => {
+  const { closeBottomSheet } = useBottomSheet();
+  const [selectedDate, setSelectedDate] = useState<ValuePiece>(new Date());
+
+  const [selectMenu, setSelectMenu] = useState('calendar');
+  const [selectAMTime, setSelectAMTime] = useState('');
+  const [selectPMTime, setSelectPMTime] = useState('');
+
+  const handleDateChange = (date: Date) => {
+    setSelectedDate(date);
+  };
+
+  const handleTimeChange = (time: string, isAM: boolean) => {
+    if (isAM) {
+      setSelectAMTime(time);
+      setSelectPMTime('');
+    } else {
+      setSelectPMTime(time);
+      setSelectAMTime('');
+    }
+  };
+
+  const handleApply = () => {
+    const formattedDate = moment(selectedDate).format('MM/DD');
+    const timeToUse = selectAMTime !== '' ? `오전 ${selectAMTime}` : `오후 ${selectPMTime}`;
+    console.log('선택 날짜', formattedDate);
+    console.log('선택 시간', timeToUse);
+    closeBottomSheet();
+  };
+
+  return (
+    <S.BottomSheetContent>
+      <S.BottomSheetHeader onClick={() => setSelectMenu('calendar')}>
+        <span className="select_fitness">
+          <CalendarIcon />
+          운동 날짜 선택
+        </span>
+        {selectMenu === 'calendar' ? <TopArrowIcon /> : <BottomArrowIcon />}
+      </S.BottomSheetHeader>
+      {selectMenu === 'calendar' && (
+        <S.Content>
+          <S.CalendarWrapper>
+            <ReactCalendar
+              onChange={handleDateChange as any}
+              value={selectedDate}
+              calendarType={'US'}
+              formatMonthYear={(locale, date) => moment(date).format('YYYY.MM')}
+              formatDay={(locale, date) => moment(date).format('D')}
+            />
+          </S.CalendarWrapper>
+        </S.Content>
+      )}
+      <S.BottomSheetHeader onClick={() => setSelectMenu('time')}>
+        <span className="select_fitness">
+          <ClockIcon />
+          운동 시간 선택
+        </span>
+        {selectMenu === 'time' ? <TopArrowIcon /> : <BottomArrowIcon />}
+      </S.BottomSheetHeader>
+      {selectMenu === 'time' && (
+        <S.Content>
+          <Time onChange={handleTimeChange} amTime={selectAMTime} pmTime={selectPMTime} />
+        </S.Content>
+      )}
+      <S.ButtonGroup>
+        <S.CancelButton onClick={closeBottomSheet}>취소</S.CancelButton>
+        <S.Button onClick={handleApply}>적용</S.Button>
+      </S.ButtonGroup>
+    </S.BottomSheetContent>
+  );
+};
+
+export default CalendarTime;

--- a/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/style.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/style.tsx
@@ -1,0 +1,206 @@
+import theme from '@styles/theme';
+import styled from 'styled-components';
+
+export const BottomSheetContent = styled.div`
+  padding: 30px 16px;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  ${theme.media.tablet} {
+    padding-left: 100px;
+  }
+
+  ${theme.media.mobile2} {
+    padding: 30px 16px;
+  }
+`;
+
+export const BottomSheetHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  border-bottom: 1px solid var(--color-gray3);
+  padding-bottom: 15px;
+  margin-bottom: 12px;
+  cursor: pointer;
+
+  .select_fitness {
+    font-weight: 700;
+    font-size: 16px;
+    line-height: 30px;
+    letter-spacing: -2.2%;
+    display: flex;
+    align-items: center;
+    gap: 15px;
+  }
+
+  .register_fitness {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 30px;
+    letter-spacing: -2%;
+  }
+`;
+
+export const Content = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  gap: 13px;
+  margin-bottom: 20px;
+`;
+
+export const ContentBox = styled.div<{ isSelected: boolean }>`
+  width: 180px;
+  height: 110px;
+  border-radius: 8px;
+  padding: 8px;
+  background-color: ${(props) => (props.isSelected ? 'var(--color-primary-main)' : 'var(--color-white)')};
+  filter: drop-shadow(0px 0px rgba(61, 64, 72, 0.1));
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: pointer;
+
+  span {
+    color: ${(props) => (props.isSelected ? 'var(--color-white)' : 'var(--color-gray8)')};
+    font-weight: 500;
+    font-size: 16px;
+    line-height: 30px;
+    letter-spacing: -2%;
+  }
+`;
+
+export const ButtonGroup = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 25px;
+  margin-top: 22px;
+`;
+
+export const CancelButton = styled.button`
+  color: #001b36;
+  width: 252px;
+  height: 46px;
+  padding: 8px;
+  border-radius: 6px;
+  border: none;
+
+  ${theme.font.ko.subTitle2}
+
+  cursor: pointer;
+`;
+
+export const Button = styled.button`
+  color: var(--color-white);
+  border-radius: 6px;
+  width: 252px;
+  height: 46px;
+  padding: 8px;
+  background-color: var(--color-primary-main);
+  ${theme.font.ko.subTitle2}
+  cursor: pointer;
+`;
+
+export const CalendarWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  font-family: 'Pretendard';
+  justify-content: center;
+
+  .react-calendar {
+    width: 100%;
+    border: none;
+    padding-bottom: 10px;
+    .react-calendar__tile--now {
+    }
+    .react-calendar__tile--now:enabled:hover,
+    .react-calendar__tile--now:enabled:focus {
+    }
+    .react-calendar__navigation {
+      justify-content: center;
+      align-items: center;
+      width: 200px;
+      margin: 0 auto;
+      margin-bottom: 25px;
+      align-items: center;
+      &:hover {
+        background-color: var(--color-white);
+      }
+      button {
+        background-color: var(--color-white);
+      }
+    }
+
+    .react-calendar__navigation__prev2-button {
+      display: none;
+    }
+    .react-calendar__navigation__next2-button {
+      display: none;
+    }
+    .react-calendar__navigation__label {
+      &:hover {
+        background-color: var(--color-white);
+      }
+    }
+
+    .react-calendar__navigation__next-button,
+    .react-calendar__navigation__prev-button {
+      font-size: 25px;
+      padding-bottom: 4px;
+    }
+
+    .react-calendar__navigation__label > span {
+      font-size: 16px;
+      font-weight: bold;
+      color: #000000;
+      font-family: 'Pretendard';
+    }
+
+    .react-calendar__month-view__weekdays {
+      margin-bottom: 6px;
+      justify-content: space-between;
+      font-size: 16px;
+      font-family: 'Pretendard';
+      font-weight: 400;
+    }
+
+    .react-calendar__month-view__days {
+      button:nth-of-type(7n) {
+        color: blue;
+      }
+      .react-calendar__month-view__days__day--neighboringMonth {
+        color: #757575 !important;
+      }
+    }
+
+    .react-calendar__month-view__days {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      gap: 16px 44px;
+    }
+
+    .react-calendar__month-view__days .react-calendar__tile {
+      height: 40px;
+      max-width: 40px;
+    }
+
+    .react-calendar__tile {
+      max-width: 100%;
+      font-size: 16px;
+      text-align: center;
+      border-radius: 8px;
+    }
+
+    .react-calendar__tile--active {
+      background: #001b36;
+    }
+  }
+`;

--- a/src/components/Common/BottomSheet/BottomSheetList/ExerciseArea/index.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/ExerciseArea/index.tsx
@@ -26,7 +26,7 @@ const ExerciseArea = () => {
   return (
     <S.BottomSheetContent>
       <S.BottomSheetHeader>
-        <span className="select_pitness">운동부위</span>
+        <span className="select_fitness">운동부위</span>
       </S.BottomSheetHeader>
       <S.Content>
         {dummy.map((el) => (

--- a/src/components/Common/BottomSheet/BottomSheetList/ExerciseArea/style.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/ExerciseArea/style.tsx
@@ -24,14 +24,14 @@ export const BottomSheetHeader = styled.div`
   border-bottom: 1px solid var(--color-gray3);
   padding-bottom: 15px;
 
-  .select_pitness {
+  .select_fitness {
     font-weight: 700;
     font-size: 16px;
     line-height: 30px;
     letter-spacing: -2.2%;
   }
 
-  .register_pitness {
+  .register_fitness {
     display: flex;
     align-items: center;
     gap: 6px;

--- a/src/components/Common/BottomSheet/BottomSheetList/FitnessClub/index.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/FitnessClub/index.tsx
@@ -29,8 +29,8 @@ const FitnessClub = () => {
   return (
     <S.BottomSheetContent>
       <S.BottomSheetHeader>
-        <span className="select_pitness">헬스장 선택</span>
-        <span className="register_pitness">
+        <span className="select_fitness">헬스장 선택</span>
+        <span className="register_fitness">
           <PlusIcon />
           헬스장 등록
         </span>

--- a/src/components/Common/BottomSheet/BottomSheetList/FitnessClub/style.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/FitnessClub/style.tsx
@@ -15,14 +15,14 @@ export const BottomSheetHeader = styled.div`
   border-bottom: 1px solid var(--color-gray3);
   padding-bottom: 15px;
 
-  .select_pitness {
+  .select_fitness {
     font-weight: 700;
     font-size: 16px;
     line-height: 30px;
     letter-spacing: -2.2%;
   }
 
-  .register_pitness {
+  .register_fitness {
     display: flex;
     align-items: center;
     gap: 6px;

--- a/src/components/Common/BottomSheet/BottomSheetList/Gender/index.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/Gender/index.tsx
@@ -26,7 +26,7 @@ const Gender = () => {
   return (
     <S.BottomSheetContent>
       <S.BottomSheetHeader>
-        <span className="select_pitness">성별</span>
+        <span className="select_fitness">성별</span>
       </S.BottomSheetHeader>
       <S.Content>
         {dummy.map((el) => (

--- a/src/components/Common/BottomSheet/BottomSheetList/Gender/style.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/Gender/style.tsx
@@ -15,14 +15,14 @@ export const BottomSheetHeader = styled.div`
   border-bottom: 1px solid var(--color-gray3);
   padding-bottom: 15px;
 
-  .select_pitness {
+  .select_fitness {
     font-weight: 700;
     font-size: 16px;
     line-height: 30px;
     letter-spacing: -2.2%;
   }
 
-  .register_pitness {
+  .register_fitness {
     display: flex;
     align-items: center;
     gap: 6px;

--- a/src/components/Common/BottomSheet/BottomSheetList/index.ts
+++ b/src/components/Common/BottomSheet/BottomSheetList/index.ts
@@ -1,4 +1,4 @@
 export { default as FitnessClub } from './FitnessClub';
 export { default as ExerciseArea } from './ExerciseArea';
 export { default as Gender } from './Gender';
-export { default as Calandar } from './Calandar';
+export { default as Calendar } from './Calendar';

--- a/src/components/Common/BottomSheet/BottomSheetList/index.ts
+++ b/src/components/Common/BottomSheet/BottomSheetList/index.ts
@@ -2,3 +2,4 @@ export { default as FitnessClub } from './FitnessClub';
 export { default as ExerciseArea } from './ExerciseArea';
 export { default as Gender } from './Gender';
 export { default as Calendar } from './Calendar';
+export { default as CalendarTime } from './CalendarTime';

--- a/src/components/Common/BottomSheet/index.tsx
+++ b/src/components/Common/BottomSheet/index.tsx
@@ -11,7 +11,7 @@ const BottomSheetContainer = () => {
     FitnessClub: BottomSheet['FitnessClub'],
     ExerciseArea: BottomSheet['ExerciseArea'],
     Gender: BottomSheet['Gender'],
-    Calandar: BottomSheet['Calandar'],
+    Calendar: BottomSheet['Calendar'],
     '': <></>,
   };
   const Content = bottomSheetComp[bottomsheet.name] as () => JSX.Element;

--- a/src/components/Common/BottomSheet/index.tsx
+++ b/src/components/Common/BottomSheet/index.tsx
@@ -12,6 +12,7 @@ const BottomSheetContainer = () => {
     ExerciseArea: BottomSheet['ExerciseArea'],
     Gender: BottomSheet['Gender'],
     Calendar: BottomSheet['Calendar'],
+    CalendarTime: BottomSheet['CalendarTime'],
     '': <></>,
   };
   const Content = bottomSheetComp[bottomsheet.name] as () => JSX.Element;

--- a/src/components/Common/BottomSheet/style.tsx
+++ b/src/components/Common/BottomSheet/style.tsx
@@ -35,8 +35,6 @@ export const Wrapper = styled.div`
   width: 100%;
   max-width: 620px;
   height: fit-content;
-  max-height: 60%;
-  overflow-y: scroll;
   &::-webkit-scrollbar {
     display: none;
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,12 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "src/components/Common/BottomSheet/BottomSheetList/Calandar/index.js"],
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    "src/components/Common/BottomSheet/BottomSheetList/Calendar/index.js"
+  ],
   "exclude": ["node_modules"],
   "extends": "./tsconfig.path"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3172,6 +3172,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
 
+moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz"


### PR DESCRIPTION
## What is this PR?🔍

글쓰기 페이지에서 날짜와 시간을 설정하기 위해 BottomSheet - CalendarTime 컴포넌트를 생성했습니다.


## 🔨 설명

BottomSheet - 달력과 시간 컴포넌트 생성

## 작업사항
- BottomSheet 에서 날짜와 시간을 선택하는 컴포넌트인 CalendarTime 컴포넌트를 생성했습니다.
- react calendar를 커스텀해 피그마 디자인에 맞게 수정했습니다.
- 토글이 열려있을 때 사용하는 화살표 아이콘을 업로드했습니다.
- 디자인 되어 있는 날짜 포맷을 맞추기 위해 moment 라이브러리를 설치했습니다.
- 피그마 디자인에서는 날짜 선택 토글과 시간 선택 토글이 모두 닫혀있는 디자인도 있으나 이를 고려해 선택한 토글 메뉴에 따라 모두 열리게 할 경우 BottomSheet 의 길이가 넘쳐나서 스크롤이 생기게 됩니다. 이는 사용자의 ui/ux를 해칠 수 있다 생각되어 한 가지 메뉴만 열리도록 구현했습니다.
- 날짜를 선택한 후 시간 토글 메뉴를 열고, 다시 날짜 선택 토글을 열 때 기존에 선택했던 날짜가 그대로 선택되어 있습니다. 시간 설정 또한 마찬가지로 구현되어 있습니다. 시간을 선택한 후 날짜 선택 토글을 열었다가, 다시 시간 선택 토글을 열면 기존에 선택한 시간이 그대로 선택되어 있습니다. 영상 참고 바랍니다.
- 해당 이슈는 글쓰기 페이지에서 사용하는 것을 목적으로 둔 것이 아니라 CalendarTime 컴포넌트 생성만을 목적으로 했기 때문에 페이지에서 사용하는 것은 구현되어 있지 않습니다. 추가로 첨부하는 영상에 나와있듯이 BottomSheet에서 적용 버튼을 누르면 설정한 날짜와 시간 데이터가 콘솔에 출력되도록 하는 것까지만 구현되어 있습니다. 이때, 날짜는 글쓰기 페이지에서 사용하는 날짜 포맷을 사용합니다.

### 피그마 디자인
| 초기 상태 (날짜 선택) | 시간 선택 | 모두 닫았을 때 |
| -- | -- | -- | 
| <img src="https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/8c76af45-793e-48c4-bd4d-da6d4e77b1ea"> | <img src="https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/565880c7-17e8-4a10-b157-e37dff835bc0"> | <img src="https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/b9647510-f586-49ba-bbc3-835074716a59"> |

## 🖥️ 구현 스크린샷
| 초기 상태 - 날짜 선택: 오늘 | 날짜 선택 | 
| -- | -- | 
| <img src="https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/427fe5e2-df7f-4c5b-bb66-e6c4fc3c1b21"> | <img src="https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/44bb240d-8705-4355-a186-4aaa86fe24f9"> | 

| 시간 선택 토글 클릭 | 시간 선택 |
| -- | -- |
| <img src="https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/1672f4dc-3cbf-49ad-9e09-b301c3705173"> | <img src="https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/eaeed754-9c6f-430a-ba30-1586d1d48be7"> |


## 🎥 구현 영상

https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/8a3a42da-bec2-4d43-a345-aee1f0aceeae


## ⚠️ 참고사항
아래와 같이 배포 에러가 뜨는 이유는 글쓰기 페이지에서 사용하는 BottomSheet의 이름을 수정하지 않았기 때문입니다.
이는 해당 컴포넌트를 사용하는 글쓰기 페이지 관련 브랜치에서 작업 후 pr 올릴 예정이니 신경쓰지 않으셔도 됩니다!
<img width="1166" alt="image" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/ee0f3e7d-2005-4126-ac18-d8945695eafb">

