### PR TITLE
[Feat]:  글쓰기 페이지 헬스장 위치 검색 기능 구현

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,5 +9,8 @@
   "env": {
     "browser": true,
     "es6": true
+  },
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off" // any 타입 사용 허용
   }
 }

--- a/src/components/PostWrite/Content/index.tsx
+++ b/src/components/PostWrite/Content/index.tsx
@@ -9,12 +9,14 @@ import Map from '../Map';
 import SearchGym from '../SearchGym';
 import { useBottomSheet } from '@hooks/common';
 import { GymInfoType } from '@typing/user';
+import { useRecoilState } from 'recoil';
+import { isMapShowState } from '@recoil/postWrite';
 
 const Content = () => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [selectedExercisePart, setSelectedExercisePart] = useState('');
-  const [isMapShow, setIsMapShow] = useState(false);
+  const [isMapShow, setIsMapShow] = useRecoilState(isMapShowState);
   const [searchPlace, setSearchPlace] = useState<GymInfoType>({
     name: '',
     location: '',

--- a/src/components/PostWrite/Content/index.tsx
+++ b/src/components/PostWrite/Content/index.tsx
@@ -6,12 +6,21 @@ import BottomArrowIcon from '@assets/icon/bottom-arrow.svg';
 import SearchIcon from '@assets/icon/search.svg';
 import AddImgIcon from '@assets/icon/addImg.svg';
 import Map from '../Map';
+import SearchGym from '../SearchGym';
 import { useBottomSheet } from '@hooks/common';
+import { GymInfoType } from '@typing/user';
 
 const Content = () => {
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [selectedExercisePart, setSelectedExercisePart] = useState('');
+  const [isMapShow, setIsMapShow] = useState(false);
+  const [searchPlace, setSearchPlace] = useState<GymInfoType>({
+    name: '',
+    location: '',
+    latitude: '',
+    longitude: '',
+  });
   const textarea = useRef<HTMLTextAreaElement>(null);
   const { showBottomSheet } = useBottomSheet();
 
@@ -24,6 +33,14 @@ const Content = () => {
   };
 
   const exercisePartArray = ['전신', '가슴', '등', '어깨', '하체', '코어'];
+
+  const setChangeSearchPlace = (place: any) => {
+    setSearchPlace(place);
+  };
+
+  const handleCloseSearch = () => {
+    setIsMapShow(false);
+  };
 
   const textareaResizeHandler = () => {
     if (textarea.current) {
@@ -38,89 +55,95 @@ const Content = () => {
   };
 
   return (
-    <S.Wrapper>
-      <S.TitleInputWrapper>
-        <input type="text" placeholder="제목" value={title} onChange={titleHandler} maxLength={30} />
-        <span>{title.length}/30</span>
-      </S.TitleInputWrapper>
+    <>
+      {!isMapShow ? (
+        <S.Wrapper>
+          <S.TitleInputWrapper>
+            <input type="text" placeholder="제목" value={title} onChange={titleHandler} maxLength={30} />
+            <span>{title.length}/30</span>
+          </S.TitleInputWrapper>
 
-      {/* 운동 날짜와 운동 시간 BottomSheet 사용 */}
-      <S.SelectWrapper onClick={() => showBottomSheet('Calandar')}>
-        <S.SelectArea>
-          <div>
-            <CalendarIcon />
-            <S.Subject>운동 날짜</S.Subject>
-          </div>
-          <BottomArrowIcon />
-        </S.SelectArea>
-        <S.SelectArea>
-          <div>
-            <ClockIcon />
-            <S.Subject>운동 시간</S.Subject>
-          </div>
-          <BottomArrowIcon />
-        </S.SelectArea>
-      </S.SelectWrapper>
+          {/* 운동 날짜와 운동 시간 BottomSheet 사용 */}
+          <S.SelectWrapper onClick={() => showBottomSheet('CalendarTime')}>
+            <S.SelectArea>
+              <div>
+                <CalendarIcon />
+                <S.Subject>운동 날짜</S.Subject>
+              </div>
+              <BottomArrowIcon />
+            </S.SelectArea>
+            <S.SelectArea>
+              <div>
+                <ClockIcon />
+                <S.Subject>운동 시간</S.Subject>
+              </div>
+              <BottomArrowIcon />
+            </S.SelectArea>
+          </S.SelectWrapper>
 
-      {/* 운동 부위 선택 버튼*/}
-      <S.ExercisePartArea>
-        <S.Subject>운동 부위</S.Subject>
-        <S.ExercisePartWrapper>
-          {exercisePartArray.map((part, idx) => (
-            <S.ExercisePart
-              key={idx}
-              onClick={() => setSelectedExercisePart(part)}
-              selected={selectedExercisePart}
-              part={part}
-            >
-              {part}
-            </S.ExercisePart>
-          ))}
-        </S.ExercisePartWrapper>
-      </S.ExercisePartArea>
+          {/* 운동 부위 선택 버튼*/}
+          <S.ExercisePartArea>
+            <S.Subject>운동 부위</S.Subject>
+            <S.ExercisePartWrapper>
+              {exercisePartArray.map((part, idx) => (
+                <S.ExercisePart
+                  key={idx}
+                  onClick={() => setSelectedExercisePart(part)}
+                  selected={selectedExercisePart}
+                  part={part}
+                >
+                  {part}
+                </S.ExercisePart>
+              ))}
+            </S.ExercisePartWrapper>
+          </S.ExercisePartArea>
 
-      {/* 헬스장 위치 검색 */}
-      <S.ExercisePlaceSearchArea>
-        <S.Subject>헬스장 위치</S.Subject>
-        <S.ExercisePlaceSearchInputWrapper>
-          <SearchIcon />
-          <input type="text" placeholder="헬스장 위치를 검색해보세요." />
-        </S.ExercisePlaceSearchInputWrapper>
-        {/* 맵 */}
-        <Map />
-      </S.ExercisePlaceSearchArea>
+          {/* 헬스장 위치 검색 */}
+          <S.ExercisePlaceSearchArea>
+            <S.Subject>헬스장 위치</S.Subject>
+            <S.ExercisePlaceSearchInputWrapper onClick={() => setIsMapShow(true)}>
+              <SearchIcon />
+              <input type="text" placeholder="헬스장 위치를 검색해보세요." />
+            </S.ExercisePlaceSearchInputWrapper>
+            {/* 맵 */}
+            <Map searchPlace={searchPlace.name} />
+          </S.ExercisePlaceSearchArea>
 
-      {/* 상세설명 */}
-      <S.DescriptionArea>
-        <S.Subject>상세설명</S.Subject>
-        <S.DescriptionImageWrapper>
-          <AddImgIcon />
-          {/* 사진 없으면 아이콘 + 사진추가 버튼? */}
-          {/* 사진 있으면 사진 3장까지? */}
-          <div></div>
-          <div>
-            <S.DescriptionImage></S.DescriptionImage>
-            <S.DescriptionImage></S.DescriptionImage>
-            <S.DescriptionImage></S.DescriptionImage>
-          </div>
-        </S.DescriptionImageWrapper>
-        <S.DescriptionTextAreaWrapper>
-          <span>{description.length}/100</span>
-          <textarea
-            ref={textarea}
-            name="description"
-            value={description}
-            onChange={textareaOnChangeHandler}
-            maxLength={100}
-            rows={1}
-            placeholder="내용을 입력해주세요."
-          ></textarea>
-        </S.DescriptionTextAreaWrapper>
-      </S.DescriptionArea>
+          {/* 상세설명 */}
+          <S.DescriptionArea>
+            <S.Subject>상세설명</S.Subject>
+            <S.DescriptionImageWrapper>
+              <AddImgIcon />
+              {/* 사진 없으면 아이콘 + 사진추가 버튼? */}
+              {/* 사진 있으면 사진 3장까지? */}
+              <div></div>
+              <div>
+                <S.DescriptionImage></S.DescriptionImage>
+                <S.DescriptionImage></S.DescriptionImage>
+                <S.DescriptionImage></S.DescriptionImage>
+              </div>
+            </S.DescriptionImageWrapper>
+            <S.DescriptionTextAreaWrapper>
+              <span>{description.length}/100</span>
+              <textarea
+                ref={textarea}
+                name="description"
+                value={description}
+                onChange={textareaOnChangeHandler}
+                maxLength={100}
+                rows={1}
+                placeholder="내용을 입력해주세요."
+              ></textarea>
+            </S.DescriptionTextAreaWrapper>
+          </S.DescriptionArea>
 
-      {/* 업로드 버튼 */}
-      <S.UploadBtn>업로드</S.UploadBtn>
-    </S.Wrapper>
+          {/* 업로드 버튼 */}
+          <S.UploadBtn>업로드</S.UploadBtn>
+        </S.Wrapper>
+      ) : (
+        <SearchGym setChangeSearchPlace={setChangeSearchPlace} handleCloseSearch={handleCloseSearch} />
+      )}
+    </>
   );
 };
 

--- a/src/components/PostWrite/Header/index.tsx
+++ b/src/components/PostWrite/Header/index.tsx
@@ -1,9 +1,12 @@
 import * as S from './style';
 import LeftArrowIcon from '@assets/icon/left-arrow.svg';
+import { isMapShowState } from '@recoil/postWrite';
 import { useRouter } from 'next/router';
+import { useRecoilValue } from 'recoil';
 
 const Header = () => {
   const router = useRouter();
+  const isMapShow = useRecoilValue(isMapShowState);
 
   const handleRouteBack = () => {
     router.back();
@@ -12,7 +15,7 @@ const Header = () => {
   return (
     <S.Wrapper>
       <LeftArrowIcon onClick={handleRouteBack} />
-      <span>글쓰기</span>
+      <span>{isMapShow ? '헬스장 검색' : '글쓰기'}</span>
     </S.Wrapper>
   );
 };

--- a/src/components/PostWrite/SearchGym/index.tsx
+++ b/src/components/PostWrite/SearchGym/index.tsx
@@ -1,0 +1,71 @@
+import React, { useState, useEffect, useRef } from 'react';
+import * as S from './style';
+import Map from '../SearchMap';
+import { GymInfoType } from '@typing/user';
+import SearchIcon from '@assets/icon/search.svg';
+
+interface Props {
+  setChangeSearchPlace: (place: any) => void;
+  handleCloseSearch: () => void;
+}
+
+const SearchGym = ({ setChangeSearchPlace, handleCloseSearch }: Props) => {
+  const [searchPlace, setSearchPlace] = useState('');
+  const [clickedLocation, setClickedLocation] = useState<GymInfoType>({
+    name: '',
+    location: '',
+    latitude: '',
+    longitude: '',
+  });
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchPlace(e.target.value);
+  };
+
+  const handleClickLocation = (place: any) => {
+    setClickedLocation({
+      name: place.place_name,
+      location: place.address_name,
+      latitude: place.x,
+      longitude: place.y,
+    });
+  };
+
+  const handleClickGym = () => {
+    setChangeSearchPlace(clickedLocation);
+    handleCloseSearch();
+  };
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+    return () => {
+      setClickedLocation({
+        name: '',
+        location: '',
+        latitude: '',
+        longitude: '',
+      });
+      setSearchPlace('');
+    };
+  }, []);
+
+  return (
+    <S.Wrapper>
+      <S.Input>
+        <SearchIcon />
+        <input ref={inputRef} onChange={handleChangeInput} placeholder="헬스장을 검색해주세요." />
+      </S.Input>
+      <Map searchPlace={searchPlace} handleClickLocation={handleClickLocation} />
+      <S.ButtonGroup>
+        <S.CancelButton onClick={handleCloseSearch}>취소</S.CancelButton>
+        <S.Button onClick={handleClickGym}>등록</S.Button>
+      </S.ButtonGroup>
+    </S.Wrapper>
+  );
+};
+
+export default SearchGym;

--- a/src/components/PostWrite/SearchGym/style.tsx
+++ b/src/components/PostWrite/SearchGym/style.tsx
@@ -1,0 +1,69 @@
+import theme from '@styles/theme';
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  padding: 38px 17px;
+`;
+
+export const Input = styled.div`
+  width: 100%;
+  height: 38px;
+  padding: 1px 8px 1px 20px;
+  border-radius: 6px;
+  background-color: #eeeeee;
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  margin-bottom: 24px;
+
+  input {
+    background-color: #eeeeee;
+    border: none;
+    outline: none;
+    width: 100%;
+    height: 100%;
+
+    font-weight: 400;
+    font-size: 14px;
+    line-height: 30px;
+    letter-spacing: -2%;
+    color: var(--color-gray8);
+  }
+`;
+
+export const ButtonGroup = styled.div`
+  display: flex;
+  align-items: center;
+  width: 100%;
+  gap: 45px;
+  padding-left: 11px;
+  margin-top: 20px;
+`;
+
+export const CancelButton = styled.button`
+  color: #001b36;
+  width: 252px;
+  height: 46px;
+  padding: 8px;
+  border-radius: 6px;
+  border: none;
+
+  ${theme.font.ko.subTitle2}
+
+  cursor: pointer;
+`;
+
+export const Button = styled.button`
+  color: var(--color-white);
+  border-radius: 6px;
+  width: 252px;
+  height: 46px;
+  padding: 8px;
+  background-color: var(--color-primary-main);
+  ${theme.font.ko.subTitle2}
+  cursor: pointer;
+`;

--- a/src/components/PostWrite/SearchMap/index.tsx
+++ b/src/components/PostWrite/SearchMap/index.tsx
@@ -9,9 +9,10 @@ declare global {
 
 interface Props {
   searchPlace: string;
+  handleClickLocation: (place: any) => void;
 }
 
-export default function Map({ searchPlace }: Props) {
+export default function SearchMap({ searchPlace, handleClickLocation }: Props) {
   const [kakaoMap, setKakaoMap] = useState<any>(null);
   const [selectedPlace, setSelectedPlace] = useState<any>(null);
   const customOverLay = useRef<any>(null);
@@ -49,9 +50,9 @@ export default function Map({ searchPlace }: Props) {
 
     const ps = new window.kakao.maps.services.Places();
 
-    //검색어따라 지도에서 찾기
+    // 검색어따라 지도에서 찾기
 
-    const placesSearchCB = (data: any, status: any) => {
+    const placesSearchCB = (data: any, status: any, pagination: any) => {
       if (status === window.kakao.maps.services.Status.OK) {
         const bounds = new window.kakao.maps.LatLngBounds();
 
@@ -78,7 +79,10 @@ export default function Map({ searchPlace }: Props) {
         position: new window.kakao.maps.LatLng(place.y, place.x),
         image: checkMarker,
       });
-      setSelectedPlace(place);
+      window.kakao.maps.event.addListener(marker, 'click', function () {
+        setSelectedPlace(place);
+        handleClickLocation(place);
+      });
     }
   }, [kakaoMap, searchPlace]);
 
@@ -102,5 +106,5 @@ export default function Map({ searchPlace }: Props) {
     });
   }, [selectedPlace]);
 
-  return <div id="map" style={{ width: '100%', height: '400px', borderRadius: '8px' }}></div>;
+  return <div id="map" style={{ width: '100%', height: '70vh', borderRadius: '8px' }}></div>;
 }

--- a/src/recoil/postWrite/atom.ts
+++ b/src/recoil/postWrite/atom.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const isMapShowState = atom({
+  key: 'isMapShowState',
+  default: false,
+});

--- a/src/recoil/postWrite/index.ts
+++ b/src/recoil/postWrite/index.ts
@@ -1,0 +1,1 @@
+export * from './atom';


### PR DESCRIPTION
## What is this PR?🔍

글쓰기 페이지 헬스장 위치 검색 기능 구현했습니다.

## 📑 작업 사항
- 글쓰기 페이지 헬스장 위치 검색 기능 구현했습니다.
- 글쓰기 페이지에서 헬스장 위치 검색 인풋 클릭 시 헬스장 위치를 검색할 수 있는 컴포넌트가 활성화 됩니다. (페이지 이동x)
- 검색 컴포넌트가 열리면 자동으로 검색 인풋에 focus를 주었습니다.
- 검색 컴포넌트에서의 맵이 화면을 넘쳐나 스크롤이 생기지 않도록 하기 위해 **맵 부분의 `height`를 70vh로 설정**했습니다.
- recoil을 사용해서 검색 컴포넌트가 활성화 되면 헤더의 타이틀 문구가 바뀌도록 구현했습니다.
- 위 작업한 내용을 글쓰기 퍼블리싱 브랜치에서 보이도록 해야 하나 고민됐는데 해당 브랜치에서 바로 볼 수 있도록 페이지에서 사용하는 부분도 구현했습니다. (운동 날짜와 시간을 설정하는 BottomSheet 컴포넌트 사용 부분도 구현했습니다.)
- eslint에서 any 타입을 사용해도 오류가 뜨지 않도록 설정했습니다.

## 🎥 스크린샷

https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/6f557fad-312c-4445-90a3-446522fe1cad

## ⚠️ 참고 사항
아래와 같이 배포에러가 뜨는 이유는 BottomSheet 컴포넌트의 수정이 있었으나 Upload 페이지에서 반영하지 않았기 때문입니다.
이는 글쓰기 페이지 퍼블리싱을 하며 수정하도록 하겠습니다.
(upload 페이지 및 Upload 컴포넌트 삭제 및 메인페이지에서 글쓰기 버튼 클릭 시 이동되는 링크 수정 예정)
![image](https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/db7e5f69-f09f-46d6-b78f-bd67d32d99fe)

