### PR TITLE
[Feat]: 메인페이지 api

### DIFF
--- a/src/apis/base.ts
+++ b/src/apis/base.ts
@@ -7,9 +7,9 @@ export const customAxios: AxiosInstance = axios.create({
 });
 
 const createApiMethod =
-  (_axiosInstace: AxiosInstance, methodType: Method) =>
+  (_axiosInstance: AxiosInstance, methodType: Method) =>
   (config: AxiosRequestConfig): Promise<any> => {
-    _axiosInstace.interceptors.response.use(
+    _axiosInstance.interceptors.response.use(
       (response) => {
         return response;
       },
@@ -17,7 +17,7 @@ const createApiMethod =
         return error.response;
       }
     );
-    return _axiosInstace({
+    return _axiosInstance({
       ...config,
       method: methodType,
     });

--- a/src/apis/base.ts
+++ b/src/apis/base.ts
@@ -14,7 +14,7 @@ const createApiMethod =
         return response;
       },
       (error) => {
-        return error;
+        return error.response;
       }
     );
     return _axiosInstace({

--- a/src/apis/partner.ts
+++ b/src/apis/partner.ts
@@ -1,12 +1,5 @@
-import api from '@apis/base';
-import { getAccessTokenFromCookie } from '@utils/token';
+import authApi from '@apis/auth';
 
 export const getTodayPartner = () => {
-  const accessToken = getAccessTokenFromCookie();
-  return api.get({
-    url: 'api/partner/today',
-    headers: {
-      Authorization: `Bearer ${accessToken}`,
-    },
-  });
+  return authApi.get('api/partner/today');
 };

--- a/src/apis/partner.ts
+++ b/src/apis/partner.ts
@@ -1,0 +1,12 @@
+import api from '@apis/base';
+import { getAccessTokenFromCookie } from '@utils/token';
+
+export const getTodayPartner = () => {
+  const accessToken = getAccessTokenFromCookie();
+  return api.get({
+    url: 'api/partner/today',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+};

--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -12,3 +12,9 @@ export const createPost = (formData: FormData) => {
     },
   });
 };
+
+export const getMainPosts = () => {
+  return api.get({
+    url: 'api/recruitment/main',
+  });
+};

--- a/src/components/Common/Card/index.tsx
+++ b/src/components/Common/Card/index.tsx
@@ -4,24 +4,30 @@ import * as S from './style';
 
 interface Props {
   size: 'main' | 'matching';
+  status: '모집중' | '모집완료' | '기간만료';
+  preferGender: '남성만' | '여성만' | '성별무관';
+  title: string;
+  gym: string;
+  startedAt: string;
+  imgUrl: string;
 }
 
-const Card = ({ size }: Props) => {
+const Card = ({ size, status, preferGender, title, gym, startedAt, imgUrl }: Props) => {
   return (
     <S.Wrapper size={size}>
-      <S.ImgBox>
+      <S.ImgBox imgUrl={imgUrl}>
         <S.Badge>
-          <S.Recruit>모집중</S.Recruit>
-          <S.Gender>남성만</S.Gender>
+          <S.Recruit>{status}</S.Recruit>
+          <S.Gender>{preferGender}</S.Gender>
         </S.Badge>
       </S.ImgBox>
       <S.Description>
-        <span className="title">함께 운동해용</span>
+        <span className="title">{title}</span>
         <span>
           <MapMarkerIcon />
-          스포애니 성산점
+          <span className="gym">{gym}</span>
         </span>
-        <span>운동날짜 2023.03.03 20:00</span>
+        <span>운동날짜 {startedAt}</span>
       </S.Description>
     </S.Wrapper>
   );

--- a/src/components/Common/Card/style.tsx
+++ b/src/components/Common/Card/style.tsx
@@ -23,12 +23,12 @@ export const Wrapper = styled.article<{ size: string }>`
   }
 `;
 
-export const ImgBox = styled.div`
+export const ImgBox = styled.div<{ imgUrl: string }>`
   position: relative;
   width: 100%;
   height: 208px;
-  background-color: var(--color-gray3);
   border-radius: 8px;
+  background: no-repeat center/contain url(${(props) => process.env.NEXT_PUBLIC_IMAGE_URL + props.imgUrl});
 `;
 
 export const Description = styled.div`
@@ -36,8 +36,13 @@ export const Description = styled.div`
   flex-direction: column;
   gap: 7px;
   width: 100%;
+  padding: 0 5px;
 
   .title {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
     ${theme.font.ko.subTitle1}
     font-size: 16px;
 
@@ -45,7 +50,7 @@ export const Description = styled.div`
       font-size: 17px;
     }
   }
-  span {
+  > span {
     ${theme.font.ko.body1}
     font-size: 13px;
     display: flex;
@@ -55,6 +60,12 @@ export const Description = styled.div`
       font-size: 13px;
     }
   }
+  .gym {
+    display: block;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
 `;
 
 export const Badge = styled.div`
@@ -63,29 +74,22 @@ export const Badge = styled.div`
   left: 10px;
   display: flex;
   gap: 7px;
+  > div {
+    width: 43px;
+    height: 23px;
+    border-radius: 4px;
+    padding: 6px 8px 6px 8px;
+    color: var(--color-white);
+    font-size: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
 `;
 export const Recruit = styled.div`
-  width: 43px;
-  height: 23px;
-  border-radius: 4px;
-  padding: 6px 8px 6px 8px;
   background-color: var(--color-secondary-main);
-  color: var(--color-white);
-  ${theme.font.ko.button}
-  font-size: 10px;
-  display: flex;
-  align-items: center;
 `;
 
 export const Gender = styled.div`
-  width: 43px;
-  height: 23px;
-  border-radius: 4px;
-  padding: 6px 8px 6px 8px;
   background-color: var(--color-primary-main);
-  color: var(--color-white);
-  ${theme.font.ko.button}
-  font-size: 10px;
-  display: flex;
-  align-items: center;
 `;

--- a/src/components/Common/Header/style.tsx
+++ b/src/components/Common/Header/style.tsx
@@ -1,7 +1,7 @@
 import theme from '@styles/theme';
 import styled from 'styled-components';
 
-export const Header = styled.header`
+export const Header = styled.div`
   width: 100%;
   height: 60px;
   padding: 10px 24px 10px 24px;

--- a/src/components/Main/Contents/index.tsx
+++ b/src/components/Main/Contents/index.tsx
@@ -1,51 +1,74 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import RightArrowIcon from '@assets/icon/right-arrow.svg';
 import { Card } from '@components/Common';
 import * as S from './style';
 import { useGetTodayPartner } from '@hooks/MainPage/queries';
+import useGetPosts from '@hooks/MainPage/queries/useGetPosts';
+import { MainPost } from '@typing/post';
+import { getAccessTokenFromCookie } from '@utils/token';
 
 const Contents = () => {
-  const { data } = useGetTodayPartner();
-  console.log('test', data);
+  const [todayPartner, setTodayPartner] = useState({
+    recruitmentId: null,
+    partnerName: '',
+    workoutPart: '',
+    startedAt: '',
+    gym: '',
+  });
+
+  const accessToken = getAccessTokenFromCookie();
+  const { data: todayPartnerData } = useGetTodayPartner();
+
+  useEffect(() => {
+    if (accessToken) {
+      console.log('test', todayPartnerData?.data);
+      setTodayPartner({ ...todayPartnerData?.data.data });
+    }
+  }, [accessToken, todayPartnerData]);
+
+  const { data: mainPosts } = useGetPosts();
+  const mainPostArray = mainPosts?.data.data;
 
   return (
     <S.Wrapper>
+      {accessToken && mainPostArray && (
+        <S.Content>
+          <S.Title href={'/apply'}>
+            <span>오늘의 약속</span>
+            <RightArrowIcon />
+          </S.Title>
+          <S.PromiseContents>
+            <S.PromiseContent>
+              <span>파트너</span>
+              <span className="description">{todayPartner.partnerName} 님</span>
+            </S.PromiseContent>
+            <S.Contour />
+            <S.PromiseContent>
+              <span>운동부위</span>
+              <span className="description">{todayPartner.workoutPart}</span>
+            </S.PromiseContent>
+            <S.Contour />
+            <S.PromiseContent>
+              <span>운동날짜</span>
+              <span className="description">{todayPartner.startedAt}</span>
+            </S.PromiseContent>
+            <S.Contour />
+            <S.PromiseContent>
+              <span>위치</span>
+              <span className="description">{todayPartner.gym}</span>
+            </S.PromiseContent>
+          </S.PromiseContents>
+        </S.Content>
+      )}
       <S.Content>
-        <S.Title>
-          <span>오늘의 약속</span>
-          <RightArrowIcon />
-        </S.Title>
-        <S.PromiseContents>
-          <S.PromiseContent>
-            <span>파트너</span>
-            <span className="description">차무식 님</span>
-          </S.PromiseContent>
-          <S.Contour />
-          <S.PromiseContent>
-            <span>운동부위</span>
-            <span className="description">어깨</span>
-          </S.PromiseContent>
-          <S.Contour />
-          <S.PromiseContent>
-            <span>운동날짜</span>
-            <span className="description">2023.03.03.20:00</span>
-          </S.PromiseContent>
-          <S.Contour />
-          <S.PromiseContent>
-            <span>위치</span>
-            <span className="description">스포애니 성산점</span>
-          </S.PromiseContent>
-        </S.PromiseContents>
-      </S.Content>
-      <S.Content>
-        <S.Title>
+        <S.Title href={'/matching'}>
           <span>파트너 찾기</span>
           <RightArrowIcon />
         </S.Title>
         <S.CardList>
-          {Array.from({ length: 9 }, (_, index) => index).map((el) => (
-            <Card key={el} size={'main'} />
-          ))}
+          {mainPostArray && mainPostArray.length > 0
+            ? mainPostArray.map((post: MainPost) => <Card key={post.id} size={'main'} {...post} />)
+            : '모집중인 파트너가 없습니다.'}
         </S.CardList>
       </S.Content>
     </S.Wrapper>

--- a/src/components/Main/Contents/index.tsx
+++ b/src/components/Main/Contents/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import RightArrowIcon from '@assets/icon/right-arrow.svg';
 import { Card } from '@components/Common';
 import * as S from './style';
@@ -8,30 +8,15 @@ import { MainPost } from '@typing/post';
 import { getAccessTokenFromCookie } from '@utils/token';
 
 const Contents = () => {
-  const [todayPartner, setTodayPartner] = useState({
-    recruitmentId: null,
-    partnerName: '',
-    workoutPart: '',
-    startedAt: '',
-    gym: '',
-  });
-
-  const accessToken = getAccessTokenFromCookie();
   const { data: todayPartnerData } = useGetTodayPartner();
-
-  useEffect(() => {
-    if (accessToken) {
-      console.log('test', todayPartnerData?.data);
-      setTodayPartner({ ...todayPartnerData?.data.data });
-    }
-  }, [accessToken, todayPartnerData]);
-
   const { data: mainPosts } = useGetPosts();
   const mainPostArray = mainPosts?.data.data;
+  const todayPartner = todayPartnerData?.data;
+  const accessToken = getAccessTokenFromCookie();
 
   return (
     <S.Wrapper>
-      {accessToken && mainPostArray && (
+      {accessToken && todayPartner && (
         <S.Content>
           <S.Title href={'/apply'}>
             <span>오늘의 약속</span>

--- a/src/components/Main/Contents/index.tsx
+++ b/src/components/Main/Contents/index.tsx
@@ -2,8 +2,12 @@ import React from 'react';
 import RightArrowIcon from '@assets/icon/right-arrow.svg';
 import { Card } from '@components/Common';
 import * as S from './style';
+import { useGetTodayPartner } from '@hooks/MainPage/queries';
 
 const Contents = () => {
+  const { data } = useGetTodayPartner();
+  console.log('test', data?.response.data);
+
   return (
     <S.Wrapper>
       <S.Content>

--- a/src/components/Main/Contents/index.tsx
+++ b/src/components/Main/Contents/index.tsx
@@ -6,7 +6,7 @@ import { useGetTodayPartner } from '@hooks/MainPage/queries';
 
 const Contents = () => {
   const { data } = useGetTodayPartner();
-  console.log('test', data?.response.data);
+  console.log('test', data);
 
   return (
     <S.Wrapper>

--- a/src/components/Main/Contents/style.tsx
+++ b/src/components/Main/Contents/style.tsx
@@ -1,4 +1,5 @@
 import theme from '@styles/theme';
+import Link from 'next/link';
 import styled from 'styled-components';
 
 export const Wrapper = styled.section`
@@ -16,7 +17,7 @@ export const Content = styled.section`
   gap: 20px;
 `;
 
-export const Title = styled.div`
+export const Title = styled(Link)`
   display: flex;
   justify-content: flex-start;
   align-items: center;
@@ -24,6 +25,7 @@ export const Title = styled.div`
   width: 100%;
   ${theme.font.ko.subTitle1}
   font-size: 16px;
+  cursor: pointer;
 `;
 
 export const PromiseContents = styled.div`

--- a/src/components/Matching/MatchingPosts/index.tsx
+++ b/src/components/Matching/MatchingPosts/index.tsx
@@ -3,11 +3,38 @@ import { Card } from '@components/Common';
 import * as S from './style';
 
 const MatchingPosts = () => {
+  const dummy_data = [
+    {
+      gym: '판교 헬스장',
+      id: 30,
+      imgUrl: 'all-main.jpg',
+      startedAt: '2023.06.30 13:00',
+      title: '3대 250 이상 보조구해요!! ',
+      workoutPart: '전신',
+    },
+    {
+      gym: '판교 헬스장',
+      id: 30,
+      imgUrl: 'all-main.jpg',
+      startedAt: '2023.06.30 13:00',
+      title: '3대 250 이상 보조구해요!! ',
+      workoutPart: '전신',
+    },
+    {
+      gym: '판교 헬스장',
+      id: 30,
+      imgUrl: 'all-main.jpg',
+      startedAt: '2023.06.30 13:00',
+      title: '3대 250 이상 보조구해요!! ',
+      workoutPart: '전신',
+    },
+  ];
+
   return (
     <S.Wrapper>
       <S.CardList>
-        {Array.from({ length: 9 }, (_, index) => index).map((el) => (
-          <Card key={el} size={'matching'} />
+        {dummy_data.map((el) => (
+          <Card key={el.id} size={'matching'} status={'모집중'} preferGender={'성별무관'} {...el} />
         ))}
       </S.CardList>
     </S.Wrapper>

--- a/src/constants/querykeys.ts
+++ b/src/constants/querykeys.ts
@@ -2,4 +2,5 @@ export const queryKeys = {
   signUp: ['signUp'],
   me: ['me'],
   partner: ['partner'],
+  mainPost: ['mainPost'],
 } as const;

--- a/src/constants/querykeys.ts
+++ b/src/constants/querykeys.ts
@@ -1,4 +1,5 @@
 export const queryKeys = {
   signUp: ['signUp'],
   me: ['me'],
+  partner: ['partner'],
 } as const;

--- a/src/hooks/MainPage/queries/index.ts
+++ b/src/hooks/MainPage/queries/index.ts
@@ -1,0 +1,1 @@
+export { default as useGetTodayPartner } from './useGetTodayPartner';

--- a/src/hooks/MainPage/queries/useGetPosts.ts
+++ b/src/hooks/MainPage/queries/useGetPosts.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@constants/querykeys';
+import { getMainPosts } from '@apis/post';
+
+const useGetPosts = () => {
+  return useQuery(queryKeys.mainPost, () => getMainPosts(), {});
+};
+
+export default useGetPosts;

--- a/src/hooks/MainPage/queries/useGetTodayPartner.ts
+++ b/src/hooks/MainPage/queries/useGetTodayPartner.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@constants/querykeys';
+import { getAccessTokenFromCookie } from '@utils/token';
+import { getTodayPartner } from '@apis/partner';
+
+const useGetTodayPartner = () => {
+  const token = getAccessTokenFromCookie();
+
+  return useQuery(queryKeys.partner, () => getTodayPartner(), {
+    enabled: !!token,
+  });
+};
+
+export default useGetTodayPartner;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,12 +3,20 @@ import { Header, Navigation, MainLayout } from '@components/Common';
 import { Banner, Contents } from '@components/Main';
 
 const Main = () => {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => {
+    setMounted(true);
+  }, []);
   return (
-    <MainLayout>
-      <Banner />
-      <Contents />
-    </MainLayout>
+    mounted && (
+      <MainLayout>
+        <Banner />
+        <Contents />
+      </MainLayout>
+    )
   );
 };
 
 export default Main;
+
+import { useState, useEffect } from 'react';

--- a/src/typing/post.ts
+++ b/src/typing/post.ts
@@ -1,4 +1,4 @@
-import { times } from '@constants/post';
+import { exercisePartArray, times } from '@constants/post';
 import { GymInfoType } from './user';
 
 export interface Post {
@@ -17,4 +17,15 @@ export interface TimeType {
 
 export interface StartedAtDate extends TimeType {
   date: string;
+}
+
+export interface MainPost {
+  id?: number;
+  status: '모집중' | '모집완료' | '기간만료';
+  preferGender: '남성만' | '여성만' | '성별무관';
+  workoutPart: typeof exercisePartArray;
+  title: string;
+  gym: string;
+  startedAt: string;
+  imgUrl: string;
 }


### PR DESCRIPTION
## What is this PR?🔍
메인페이지 api 작업

## 작업 상세 사항
- react Query를 이용해 오늘의 약속 파트너 조회 api와 메인 페이지 포스터 api 요청
- 로그인 여부에 따라 오늘의 약속 파트너 보여주기
- 카드 컴포넌트를 props에 넣는 데이터에 따라 해당 내용들이 보이도록 수정
- 카드 컴포넌트 스타일 수정

Card 컴포넌트
```typescript
interface Props {
  size: 'main' | 'matching';
  status: '모집중' | '모집완료' | '기간만료';
  preferGender: '남성만' | '여성만' | '성별무관';
  title: string;
  gym: string;
  startedAt: string;
  imgUrl: string;
}
```

| 로그인o | 로그인x |
| -- | -- |
| <img src="https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/5dd420d2-be8a-4cd0-a62b-24fecacd0b27"> | <img src="https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/69f01f79-a7a8-4512-8e22-8cbd80f8fbeb"> |

### 참고사항
- 마지막 커밋 useQuery가 아니라 react Query 입니다..
- 배포 에러 해결하기 위해 파트너 찾기 페이지에서 더미 데이터 사용했습니다.
- 파트너 찾기 페이지에서 카드 컴포넌트 디자인이 깨지는 모습 발견했습니다. 이후 파트너 찾기 페이지 작업할 때 해결하도록 하겠습니다.
<img width="350" alt="image" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/2dc3a9ed-9ad4-4df9-a250-0c3db14fef88">
