### PR TITLE
[Feat]: 모집글 상세 페이지 추가 작업

### DIFF
--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -31,3 +31,7 @@ export const getMainPosts = () => {
     url: 'api/recruitment/main',
   });
 };
+
+export const checkApplyStatus = (id: number) => {
+  return authApi.get(`/api/recruitment/${id}/application`);
+};

--- a/src/components/PostDetail/Content/index.tsx
+++ b/src/components/PostDetail/Content/index.tsx
@@ -74,8 +74,8 @@ const Content = ({ isOther, post, applyStatus }: Props) => {
 
         <S.Writer>
           <div>
-            <S.ImageBox>
-              {post.profileUrl ? (
+            {post.profileUrl ? (
+              <S.ImageBox>
                 <Image
                   src={createImageUrl(post.profileUrl as string)}
                   priority
@@ -84,10 +84,11 @@ const Content = ({ isOther, post, applyStatus }: Props) => {
                   alt="profile"
                   style={{ objectFit: 'cover' }}
                 />
-              ) : (
-                <ProfileIcon />
-              )}
-            </S.ImageBox>
+              </S.ImageBox>
+            ) : (
+              <ProfileIcon />
+            )}
+
             <S.WriterInfo>
               <div>
                 <span>{post.nickname}</span>

--- a/src/components/PostDetail/Content/index.tsx
+++ b/src/components/PostDetail/Content/index.tsx
@@ -78,7 +78,9 @@ const Content = ({ isOther, post }: Props) => {
               {post.profileUrl ? (
                 <Image
                   src={createImageUrl(post.profileUrl as string)}
-                  fill
+                  priority
+                  width={80}
+                  height={80}
                   alt="profile"
                   style={{ objectFit: 'cover' }}
                 />

--- a/src/components/PostDetail/Content/index.tsx
+++ b/src/components/PostDetail/Content/index.tsx
@@ -91,7 +91,7 @@ const Content = ({ isOther, post }: Props) => {
                 <span>{post.nickname}</span>
                 <S.Gender>{post.gender}</S.Gender>
               </div>
-              <span>{moment(post.createdAt.date).format('yyyy.MM.DD')}</span>
+              <span>{moment(post.createdAt, 'yyyy.MM.DD HH:mm').format('yyyy.MM.DD')}</span>
             </S.WriterInfo>
           </div>
           <S.ProfileButton onClick={() => alert('프로필 상세 페이지로 이동')}>프로필 상세</S.ProfileButton>
@@ -120,7 +120,7 @@ const Content = ({ isOther, post }: Props) => {
       <S.HealthCondition>
         <div>
           <span>운동날짜</span>
-          <span>{moment(post.startedAt.date).format('yyyy.MM.DD HH:mm')}</span>
+          <span>{moment(post.startedAt, 'yyyy.MM.DD HH:mm').format('yyyy.MM.DD HH:mm')}</span>
         </div>
         <div>
           <span>선호 성별</span>

--- a/src/components/PostDetail/Content/index.tsx
+++ b/src/components/PostDetail/Content/index.tsx
@@ -17,7 +17,7 @@ import { useRouter } from 'next/router';
 interface Props {
   isOther: boolean;
   post: PostDetailType;
-  applyStatus: ApplyStatusType | undefined;
+  applyStatus?: ApplyStatusType;
 }
 
 const Content = ({ isOther, post, applyStatus }: Props) => {

--- a/src/components/PostDetail/Content/index.tsx
+++ b/src/components/PostDetail/Content/index.tsx
@@ -144,7 +144,7 @@ const Content = ({ isOther, post, applyStatus }: Props) => {
           <S.ImageWrapper>
             {post.imgUrls.map((imgUrl) => (
               <div key={imgUrl}>
-                <Image src={imgUrl} fill alt="image" style={{ objectFit: 'cover' }} />
+                <Image src={createImageUrl(imgUrl as string)} fill alt="image" style={{ objectFit: 'cover' }} />
               </div>
             ))}
           </S.ImageWrapper>

--- a/src/components/PostDetail/Content/index.tsx
+++ b/src/components/PostDetail/Content/index.tsx
@@ -31,6 +31,8 @@ const Content = ({ isOther, post, applyStatus }: Props) => {
   const [isPartnerCancelRequested, setIsPartnerCancelRequested] = useState(false);
   const [isPartnerCancel, setIsPartnerCancel] = useState(false);
 
+  console.log(post);
+
   useEffect(() => {
     if (applyStatus) {
       setApplicationId(applyStatus.applicationId);
@@ -100,15 +102,15 @@ const Content = ({ isOther, post, applyStatus }: Props) => {
         <S.HealthInfoWrapper>
           <div>
             <span>데드리프트</span>
-            <span>{post.sbd.deadLift ? `${post.sbd.deadLift} kg` : '-'}</span>
+            <span>{post.sbd?.deadLift ? `${post.sbd.deadLift} kg` : '-'}</span>
           </div>
           <div>
             <span>스쿼트</span>
-            <span>{post.sbd.squat ? `${post.sbd.squat} kg` : '-'}</span>
+            <span>{post.sbd?.squat ? `${post.sbd.squat} kg` : '-'}</span>
           </div>
           <div>
             <span>벤치</span>
-            <span>{post.sbd.benchPress ? `${post.sbd.benchPress} kg` : '-'}</span>
+            <span>{post.sbd?.benchPress ? `${post.sbd.benchPress} kg` : '-'}</span>
           </div>
           <div>
             <span>운동목표</span>

--- a/src/components/PostDetail/Content/index.tsx
+++ b/src/components/PostDetail/Content/index.tsx
@@ -14,6 +14,7 @@ import Marker from '@assets/icon/mapmarker.svg';
 import { createImageUrl } from '@utils/createImageUrl';
 import { createApplication, deleteApplication } from '@apis/application';
 import { useGetRequestedApplications } from '@hooks/application/queries';
+import { useRouter } from 'next/router';
 
 interface Props {
   isOther: boolean;
@@ -21,6 +22,8 @@ interface Props {
 }
 
 const Content = ({ isOther, post }: Props) => {
+  const router = useRouter();
+
   const { data: requestedApplications } = useGetRequestedApplications();
   const [applicationId, setApplicationId] = useState();
   const [isPartner, setIsPartner] = useState<boolean>();
@@ -96,7 +99,7 @@ const Content = ({ isOther, post }: Props) => {
               <span>{moment(post.createdAt, 'yyyy.MM.DD HH:mm').format('yyyy.MM.DD')}</span>
             </S.WriterInfo>
           </div>
-          <S.ProfileButton onClick={() => alert('프로필 상세 페이지로 이동')}>프로필 상세</S.ProfileButton>
+          <S.ProfileButton onClick={() => router.push(`/mypage/${post.memberId}`)}>프로필 상세</S.ProfileButton>
         </S.Writer>
 
         <S.HealthInfoWrapper>

--- a/src/components/PostDetail/Content/index.tsx
+++ b/src/components/PostDetail/Content/index.tsx
@@ -25,6 +25,7 @@ const Content = ({ isOther, post, applyStatus }: Props) => {
 
   const [applicationId, setApplicationId] = useState<number | null>();
   const [isPartner, setIsPartner] = useState<boolean>();
+  const [isRequestPossible] = useState(moment().isBefore(moment(post.startedAt, 'yyyy.MM.DD HH:mm')));
 
   const [isPartnerRequested, setIsPartnerRequested] = useState(false);
   const [isPartnerCancelRequested, setIsPartnerCancelRequested] = useState(false);
@@ -38,15 +39,16 @@ const Content = ({ isOther, post, applyStatus }: Props) => {
   }, [applyStatus]);
 
   const handleCreateApplication = () => {
-    createApplication(post.recruitmentId)
-      .then((response) => {
-        console.log(response);
-        setIsPartnerRequested(true);
-        setIsPartner(true);
-      })
-      .catch((error) => {
-        console.log(error);
-      });
+    isRequestPossible &&
+      createApplication(post.recruitmentId)
+        .then((response) => {
+          console.log(response);
+          setIsPartnerRequested(true);
+          setIsPartner(true);
+        })
+        .catch((error) => {
+          console.log(error);
+        });
   };
 
   const handleCancelApplication = () => {
@@ -166,7 +168,7 @@ const Content = ({ isOther, post, applyStatus }: Props) => {
               취소하기
             </S.CancelButton>
           ) : (
-            <S.PrimaryButton onClick={handleCreateApplication}>신청하기</S.PrimaryButton>
+            <S.PrimaryButton onClick={handleCreateApplication} isPossible={isRequestPossible}></S.PrimaryButton>
           )}
         </S.ButtonsWrapper>
       ) : (

--- a/src/components/PostDetail/Content/index.tsx
+++ b/src/components/PostDetail/Content/index.tsx
@@ -4,8 +4,7 @@ import * as S from './style';
 import Image from 'next/image';
 import moment from 'moment';
 
-import { PostDetailType } from '@typing/post';
-import { RequestedApplication } from '@typing/application';
+import { ApplyStatusType, PostDetailType } from '@typing/post';
 
 import { Map, Modal } from '@components/Common';
 import ProfileIcon from '@assets/icon/profilelarge.svg';
@@ -13,19 +12,18 @@ import Marker from '@assets/icon/mapmarker.svg';
 
 import { createImageUrl } from '@utils/createImageUrl';
 import { createApplication, deleteApplication } from '@apis/application';
-import { useGetRequestedApplications } from '@hooks/application/queries';
 import { useRouter } from 'next/router';
 
 interface Props {
   isOther: boolean;
   post: PostDetailType;
+  applyStatus: ApplyStatusType | undefined;
 }
 
-const Content = ({ isOther, post }: Props) => {
+const Content = ({ isOther, post, applyStatus }: Props) => {
   const router = useRouter();
 
-  const { data: requestedApplications } = useGetRequestedApplications();
-  const [applicationId, setApplicationId] = useState();
+  const [applicationId, setApplicationId] = useState<number | null>();
   const [isPartner, setIsPartner] = useState<boolean>();
 
   const [isPartnerRequested, setIsPartnerRequested] = useState(false);
@@ -33,16 +31,11 @@ const Content = ({ isOther, post }: Props) => {
   const [isPartnerCancel, setIsPartnerCancel] = useState(false);
 
   useEffect(() => {
-    const recruitmentId = post.recruitmentId;
-    const applications = requestedApplications?.data || [];
-    const filteredApplication = applications.filter(
-      (application: RequestedApplication) => application.recruitmentId === recruitmentId
-    );
-    const applicationId = filteredApplication.length ? filteredApplication[0].applicationId : null;
-
-    setApplicationId(applicationId);
-    setIsPartner(applicationId ? true : false);
-  }, [post, requestedApplications]);
+    if (applyStatus) {
+      setApplicationId(applyStatus.applicationId);
+      setIsPartner(applyStatus.isApply);
+    }
+  }, [applyStatus]);
 
   const handleCreateApplication = () => {
     createApplication(post.recruitmentId)

--- a/src/components/PostDetail/Content/style.tsx
+++ b/src/components/PostDetail/Content/style.tsx
@@ -9,15 +9,26 @@ export const Wrapper = styled.main`
 export const WriterWrapper = styled.div``;
 
 export const Writer = styled.div`
+  width: 100%;
+
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 24px;
   margin-top: 24px;
   margin-bottom: 32px;
 
-  > div {
+  & > div:first-of-type {
+    flex-grow: 1;
     display: flex;
     align-items: center;
+    justify-content: flex-start;
+    gap: 24px;
+  }
+
+  svg {
+    width: 80px;
+    height: 80px;
   }
 `;
 
@@ -27,51 +38,55 @@ export const ImageBox = styled.div`
   border-radius: 50%;
   position: relative;
   background-color: var(--color-secondary-main);
-  margin-right: 24px;
   overflow: hidden;
-
-  svg {
-    width: 80px;
-    height: 80px;
-  }
 `;
 
 export const WriterInfo = styled.div`
+  flex-grow: 1;
   display: flex;
   flex-direction: column;
   gap: 4px;
 
-  & div {
+  & > div {
     display: flex;
     align-items: center;
+    justify-content: flex-start;
     gap: 8px;
-  }
-  & :first-of-type span {
-    font-size: 18px;
-    font-weight: 700;
+
+    span {
+      flex-basis: auto;
+      display: block;
+      max-width: 16em;
+
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+
+      font-size: 18px;
+      font-weight: 700;
+    }
   }
 `;
 
 export const Gender = styled.div`
-  width: 41px;
-  height: 28px;
   border-radius: 4px;
   padding: 6px 8px 6px 8px;
   background-color: var(--color-primary-main);
   color: var(--color-white);
   font-size: 14px;
+  white-space: nowrap;
   display: flex;
   align-items: center;
 `;
 
 export const ProfileButton = styled.div`
-  width: 106px;
-  height: 48px;
+  width: fit-content;
   border-radius: 6px;
   padding: 12px 16px;
   background-color: var(--color-primary-main);
   color: var(--color-white);
   font-size: 16px;
+  white-space: nowrap;
   display: flex;
   align-items: center;
   cursor: pointer;

--- a/src/components/PostDetail/Content/style.tsx
+++ b/src/components/PostDetail/Content/style.tsx
@@ -235,10 +235,21 @@ export const ChatButton = styled(Button)`
   color: var(--color-primary-main);
 `;
 
-export const PrimaryButton = styled(Button)`
+export const PrimaryButton = styled(Button)<{ isPossible: boolean }>`
   background-color: var(--color-primary-main);
   color: var(--color-white);
   border: none;
+
+  ${(props) =>
+    !props.isPossible &&
+    `
+    filter: grayscale(100%) contrast(50%) brightness(200%);
+    cursor: default;
+    `};
+
+  &::after {
+    content: ${(props) => (props.isPossible ? `'신청하기'` : `'신청마감'`)};
+  }
 `;
 
 export const CancelButton = styled(Button)`

--- a/src/constants/querykeys.ts
+++ b/src/constants/querykeys.ts
@@ -3,6 +3,7 @@ export const queryKeys = {
   me: ['me'],
   other: ['other'],
   postDetail: ['postDetail'],
+  applyStatus: ['applyStatus'],
   requestedApplications: ['requestedApplications'],
   receivedApplications: ['receivedApplications'],
   partner: ['partner'],

--- a/src/hooks/Post/queries/index.ts
+++ b/src/hooks/Post/queries/index.ts
@@ -1,1 +1,2 @@
 export { default as useGetPostById } from './useGetPostById';
+export { default as useCheckApplyStatus } from './useCheckApplyStatus';

--- a/src/hooks/Post/queries/useCheckApplyStatus.ts
+++ b/src/hooks/Post/queries/useCheckApplyStatus.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@constants/querykeys';
+import { checkApplyStatus } from '@apis/post';
+import { getAccessTokenFromCookie } from '@utils/token';
+
+const useCheckApplyStatus = (id: number) => {
+  const token = getAccessTokenFromCookie();
+
+  return useQuery([...queryKeys.applyStatus, id], () => checkApplyStatus(id), {
+    enabled: !!(token && id),
+  });
+};
+
+export default useCheckApplyStatus;

--- a/src/pages/post/[id].tsx
+++ b/src/pages/post/[id].tsx
@@ -1,5 +1,5 @@
 import { Content, Header } from '@components/PostDetail';
-import { useCheckIsApply } from '@hooks/Post/queries';
+import { useCheckApplyStatus } from '@hooks/Post/queries';
 import useGetPostById from '@hooks/Post/queries/useGetPostById';
 import { useGetUserInfo } from '@hooks/common/queries';
 import { useRouter } from 'next/router';
@@ -11,6 +11,8 @@ const PostDetail = () => {
   const [isSuccess, setIsSuccess] = useState(false);
 
   const { data: post } = useGetPostById(Number(postId));
+  const { data: applyStatus } = useCheckApplyStatus(Number(postId));
+
   const { currentUserId } = useGetUserInfo();
   const [isOther, setIsOther] = useState(true);
 
@@ -30,7 +32,7 @@ const PostDetail = () => {
     return (
       <>
         <Header isOther={isOther} postId={postId} />
-        <Content isOther={isOther} post={post.data.data} />
+        <Content isOther={isOther} post={post.data.data} applyStatus={applyStatus?.data} />
       </>
     );
   }

--- a/src/pages/post/[id].tsx
+++ b/src/pages/post/[id].tsx
@@ -1,4 +1,5 @@
 import { Content, Header } from '@components/PostDetail';
+import { useCheckIsApply } from '@hooks/Post/queries';
 import useGetPostById from '@hooks/Post/queries/useGetPostById';
 import { useGetUserInfo } from '@hooks/common/queries';
 import { useRouter } from 'next/router';
@@ -7,8 +8,9 @@ import { useEffect, useState } from 'react';
 const PostDetail = () => {
   const router = useRouter();
   const [postId, setPostId] = useState<number | undefined>();
-  const { data: post } = useGetPostById(Number(postId));
+  const [isSuccess, setIsSuccess] = useState(false);
 
+  const { data: post } = useGetPostById(Number(postId));
   const { currentUserId } = useGetUserInfo();
   const [isOther, setIsOther] = useState(true);
 
@@ -19,17 +21,21 @@ const PostDetail = () => {
   }, [router.query]);
 
   useEffect(() => {
-    if (post) setIsOther(post.data.data.memberId !== currentUserId);
+    setIsSuccess(post?.status === 200);
+
+    if (post?.status === 200) setIsOther(post.data.data.memberId !== currentUserId);
   }, [post, currentUserId]);
 
-  if (post) {
+  if (isSuccess) {
     return (
       <>
-        <Header isOther={isOther} postId={post.data.data.recruitmentId} />
+        <Header isOther={isOther} postId={postId} />
         <Content isOther={isOther} post={post.data.data} />
       </>
     );
-  } else return <></>;
+  }
+
+  return <></>;
 };
 
 export default PostDetail;

--- a/src/typing/post.ts
+++ b/src/typing/post.ts
@@ -28,8 +28,8 @@ export interface PostDetailType {
   description: string;
   preferGender: string;
   imgUrls: string[];
-  startedAt: StartedAtDate;
-  createdAt: CreatedAtDate;
+  startedAt: string;
+  createdAt: string;
 }
 export interface TimeType {
   meridiem: '' | '오전' | '오후';
@@ -39,7 +39,6 @@ export interface TimeType {
 export interface StartedAtDate extends TimeType {
   date: string;
 }
-
 
 export interface CreatedAtDate extends TimeType {
   date: string;

--- a/src/typing/post.ts
+++ b/src/typing/post.ts
@@ -31,6 +31,12 @@ export interface PostDetailType {
   startedAt: string;
   createdAt: string;
 }
+
+export interface ApplyStatusType {
+  isApply: boolean;
+  applicationId: number | null;
+}
+
 export interface TimeType {
   meridiem: '' | '오전' | '오후';
   time: '' | (typeof times)[number];


### PR DESCRIPTION
## What is this PR?🔍

### 목표했던 작업

- 날짜 지난 모집글 파트너 신청 막기
- 신청을 보낸 모집글인지 판단하는 API 적용
- API 수정으로 인한 날짜 형식 및 타입 변경

### 작업하면서 추가적으로 진행한 작업

- 프로필 상세 페이지로 가는 동작 추가
- 모집글 이미지가 정상적으로 표시되지 않던 문제 해결
- `sbd` 값이 `null`인 경우 대응
- 닉네임이 15자 보다 긴 경우 말줄임표로 대체
  > 원래 닉네임은 15자까지만 가능하지만, test 토큰으로 작성한 모집글의 경우 15자를 초과해서 혹시 몰라 작업했습니다.
- 프로필 기본 이미지의 컨테이너 삭제
  > 컨테이너 내부에 있을 때 완전 동그랗게 안보이고, 컨테이너 배경색이 보여 수정했습니다.
- 모집글 정보가 없는 경우에도 화면이 렌더링되는 현상 해결
  > 기존 코드에서는, 서버에서 오는 응답 자체로 모집글이 있냐 없냐를 판단하고 있었습니다. 이를 모집글 데이터가 있냐 없냐 판단하는 방식으로 변경했습니다.

## 결과 화면

- 닉네임 말줄임표
  <img width="666" alt="스크린샷 2023-07-07 오후 10 11 56" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/92ec96f0-87b8-4eb8-81b1-89f0c1d214c5">
- 모집글 이미지
  <img width="691" alt="스크린샷 2023-07-07 오후 10 12 15" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/bdbc1cb2-3cbc-444e-a02b-ea966d379d25">
- 날짜가 지난 모집글의 버튼
  <img width="686" alt="스크린샷 2023-07-07 오후 10 12 29" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/50544737-bcc9-4305-bc37-a94c55e2da52">


