### PR TITLE
[Fix] 액세스토큰 재발급이 안되던 문제 해결

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -34,7 +34,8 @@ const createAuthApi = () => {
 
               originalRequest.headers.Authorization = `Bearer ${getAccessTokenFromCookie()}`;
 
-              await axios(originalRequest);
+              const originalResponse = await axios(originalRequest);
+              return originalResponse.data;
             }
           }
         }

--- a/src/hooks/MyPage/queries/useGetMyProfile.ts
+++ b/src/hooks/MyPage/queries/useGetMyProfile.ts
@@ -1,13 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@constants/querykeys';
 import { getMyProfile } from '@apis/user';
-import { getAccessTokenFromCookie } from '@utils/token';
 
 const useGetMyProfile = () => {
-  const token = getAccessTokenFromCookie();
-
   return useQuery(queryKeys.me, () => getMyProfile(), {
-    enabled: !!token,
     staleTime: Infinity,
   });
 };


### PR DESCRIPTION
## What is this PR?🔍

- 회의 때 작업했던 것 + 다시 받아온 응답을 화면에 바로 보여주게 했습니다.

- 회의 때 작업
  - useGetMyProfile 쿼리에 의존성 제거
- 추가 작업
  - 액세스 토큰 재발급 후, 기존 요청을 다시 보내고 그 응답을 return

