### PR TITLE
[Fix]: 리프레시 토큰이 만료되었음에도 로그인 모달이 뜨지 않는 문제 해결

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -37,6 +37,8 @@ const createAuthApi = () => {
               await axios(originalRequest);
             }
           }
+
+          return Promise.reject(error);
         }
       }
     }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -25,6 +25,7 @@ export type AppPropsWithLayout = AppProps & {
 export default function App({ Component, pageProps }: AppPropsWithLayout) {
   const router = useRouter();
   const loginRequiredPages = ['/post/write', '/mypage', '/mypage/edit'];
+  const [isLoginModal, setIsLoginModal] = React.useState(false);
   const [queryClient] = React.useState(
     () =>
       new QueryClient({
@@ -37,20 +38,7 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
 
             onError: (err: unknown) => {
               if (err instanceof AxiosError && loginRequiredPages.includes(router.pathname)) {
-                return (
-                  <Modal
-                    hasArrow
-                    isOpen={true}
-                    handleClose={() => null}
-                    handleConfirm={() => router.push('/login')}
-                    handleCancel={() => router.push('/')}
-                    text={{
-                      label: '로그인 시간이 만료되었어요!\n해당 페이지는 로그인을 해야 이용이 가능해요',
-                      confirm: '로그인 하러가기',
-                      cancel: '홈으로 가기',
-                    }}
-                  />
-                );
+                setIsLoginModal(true);
               }
             },
           },
@@ -68,7 +56,24 @@ export default function App({ Component, pageProps }: AppPropsWithLayout) {
         <GlobalStyle />
         <ThemeProvider theme={theme}>
           <RecoilRoot>
-            <Layout>{getLayout(<Component {...pageProps} />)}</Layout>
+            <Layout>
+              {isLoginModal ? (
+                <Modal
+                  hasArrow
+                  isOpen={true}
+                  handleClose={() => null}
+                  handleConfirm={() => router.push('/login')}
+                  handleCancel={() => router.push('/')}
+                  text={{
+                    label: '로그인 시간이 만료되었어요!\n해당 페이지는 로그인을 해야 이용이 가능해요',
+                    confirm: '로그인 하러가기',
+                    cancel: '홈으로 가기',
+                  }}
+                />
+              ) : (
+                getLayout(<Component {...pageProps} />)
+              )}
+            </Layout>
           </RecoilRoot>
         </ThemeProvider>
         <ReactQueryDevtools initialIsOpen={false} />


### PR DESCRIPTION
## What is this PR?🔍

- auth api 조건 중, refresh token이 없을 때에도 axios error를 반환하도록 변경
- queryClient 의 onError 구문에서 바로 모달을 반환했던 기존 방법에서, isModal 변수에 true를 할당해 isModal이 참일 때 모달을 띄우는 방식으로 변경

### 결과적으로...

냅다 쿠키에서 리프레시 토큰 지워버려도 이제 모달 뜹니다. 

> 단, 액세스 토큰도 지워야 함..
> > +: 로그인이 필요한 페이지가 추가적으로 발생할 경우, loginRequiredPages 리스트에 추가해주어야 함.
