### PR TITLE
[Feat]: 모집글 검색 시 사용하는 BottomSheet-Calendar 컴포넌트 작성

### DIFF
--- a/src/components/Common/BottomSheet/BottomSheetList/Calendar/index.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/Calendar/index.tsx
@@ -5,14 +5,26 @@ import BottomArrowIcon from '@assets/icon/bottom-arrow.svg';
 import { useBottomSheet } from '@hooks/common';
 import ReactCalendar from 'react-calendar';
 import 'react-calendar/dist/Calendar.css';
-
-type ValuePiece = Date | null;
+import moment from 'moment';
+import { useRouter } from 'next/router';
+import { MATCHING_PAGE } from '@constants/route';
 
 const Calendar = () => {
   const { closeBottomSheet } = useBottomSheet();
-  const [value, onChange] = useState<ValuePiece | [ValuePiece, ValuePiece]>(new Date());
+  const [selectedDate, setSelectedDate] = useState<Date>(new Date());
+  const router = useRouter();
 
-  console.log(value);
+  const handleDateChange = (date: Date) => {
+    setSelectedDate(date);
+  };
+
+  const handleApply = () => {
+    router.push({
+      pathname: MATCHING_PAGE,
+      query: { ...router.query, date: moment(selectedDate).format('YYYY.MM.DD') },
+    });
+    closeBottomSheet();
+  };
 
   return (
     <S.BottomSheetContent>
@@ -25,12 +37,18 @@ const Calendar = () => {
       </S.BottomSheetHeader>
       <S.Content>
         <S.CalendarWrapper>
-          <ReactCalendar onChange={onChange} value={value} />
+          <ReactCalendar
+            onChange={handleDateChange as any}
+            value={selectedDate ? selectedDate : new Date()}
+            calendarType={'US'}
+            formatMonthYear={(locale, date) => moment(date).format('YYYY.MM')}
+            formatDay={(locale, date) => moment(date).format('D')}
+          />
         </S.CalendarWrapper>
       </S.Content>
       <S.ButtonGroup>
-        <S.CancelButton>취소</S.CancelButton>
-        <S.Button>적용</S.Button>
+        <S.CancelButton onClick={closeBottomSheet}>취소</S.CancelButton>
+        <S.Button onClick={handleApply}>적용</S.Button>
       </S.ButtonGroup>
     </S.BottomSheetContent>
   );

--- a/src/components/Common/BottomSheet/BottomSheetList/Calendar/style.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/Calendar/style.tsx
@@ -23,6 +23,8 @@ export const BottomSheetHeader = styled.div`
   width: 100%;
   border-bottom: 1px solid var(--color-gray3);
   padding-bottom: 15px;
+  margin-bottom: 12px;
+  cursor: pointer;
 
   .select_fitness {
     font-weight: 700;
@@ -48,7 +50,6 @@ export const BottomSheetHeader = styled.div`
 export const Content = styled.div`
   display: flex;
   flex-wrap: wrap;
-  padding: 35px 0px;
   width: 100%;
   gap: 13px;
   margin-bottom: 20px;
@@ -78,8 +79,10 @@ export const ContentBox = styled.div<{ isSelected: boolean }>`
 export const ButtonGroup = styled.div`
   display: flex;
   align-items: center;
+  justify-content: center;
   width: 100%;
   gap: 25px;
+  margin-top: 22px;
 `;
 
 export const CancelButton = styled.button`
@@ -115,12 +118,15 @@ export const CalendarWrapper = styled.div`
   .react-calendar {
     width: 100%;
     border: none;
+    padding-bottom: 10px;
     .react-calendar__tile--now {
     }
     .react-calendar__tile--now:enabled:hover,
     .react-calendar__tile--now:enabled:focus {
     }
     .react-calendar__navigation {
+      justify-content: center;
+      align-items: center;
       width: 200px;
       margin: 0 auto;
       margin-bottom: 25px;
@@ -132,6 +138,7 @@ export const CalendarWrapper = styled.div`
         background-color: var(--color-white);
       }
     }
+
     .react-calendar__navigation__prev2-button {
       display: none;
     }
@@ -144,15 +151,60 @@ export const CalendarWrapper = styled.div`
       }
     }
 
-    .react-calendar__navigation__next-button {
+    .react-calendar__navigation__next-button,
+    .react-calendar__navigation__prev-button {
       font-size: 25px;
+      padding-bottom: 4px;
     }
 
     .react-calendar__navigation__label > span {
-      font-size: 14px;
+      font-size: 16px;
       font-weight: bold;
       color: #000000;
       font-family: 'Pretendard';
+    }
+
+    .react-calendar__month-view__weekdays {
+      margin-bottom: 6px;
+      justify-content: space-between;
+      font-size: 16px;
+      font-family: 'Pretendard';
+      font-weight: 400;
+    }
+
+    .react-calendar__month-view__days {
+      button:nth-of-type(7n) {
+        color: blue;
+      }
+      .react-calendar__tile--active {
+        color: white !important;
+      }
+      .react-calendar__month-view__days__day--neighboringMonth {
+        color: #757575 !important;
+      }
+    }
+
+    .react-calendar__month-view__days {
+      width: 100%;
+      display: flex;
+      justify-content: center;
+      gap: 16px 44px;
+    }
+
+    .react-calendar__month-view__days .react-calendar__tile {
+      height: 40px;
+      max-width: 40px;
+    }
+
+    .react-calendar__tile {
+      max-width: 100%;
+      font-size: 16px;
+      text-align: center;
+      border-radius: 8px;
+    }
+
+    .react-calendar__tile--active {
+      background: #001b36;
     }
   }
 `;

--- a/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/style.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/style.tsx
@@ -79,6 +79,7 @@ export const ContentBox = styled.div<{ isSelected: boolean }>`
 export const ButtonGroup = styled.div`
   display: flex;
   align-items: center;
+  justify-content: center;
   width: 100%;
   gap: 25px;
   margin-top: 22px;


### PR DESCRIPTION
## What is this PR?🔍

모집글 검색 시 사용하는 `BottomSheet-Calendar` 컴포넌트 작성

- 기존 `BottomSheet/CalendarTime` 컴포넌트 분리 x
- 기존 `BottomSheet/Calendar` 컴포넌트 작동하도록 작성 o

- 날짜선택 시 url에 선택한 날짜가 들어가도록 했습니다.

`BottomSheet/CalendarTime` 컴포넌트를 분리하는 것보다 `Calendar` 컴포넌트만 사용하도록 기존 코드에서 기능과 스타일을 추가했습니다.

## 🖥️ 스크린샷 및 영상

https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/8c2bf6b5-f35b-4721-8889-a23c31d3f2be

⚠️ 테스트를 위해 영상에서는 글쓰기 페이지에서 사용했던 `BottomSheet/CalendarTime` 컴포넌트가 아니라 `BottomSheet/Calendar` 컴포넌트를 사용하도록 임시 수정해 찍은 영상입니다.
