### PR TITLE
[Design]: 모집글 이미지 맞춤 변경 및 배경색 삭제

### DIFF
--- a/src/components/PostDetail/Content/index.tsx
+++ b/src/components/PostDetail/Content/index.tsx
@@ -147,7 +147,7 @@ const Content = ({ isOther, post, applyStatus }: Props) => {
           <S.ImageWrapper>
             {post.imgUrls.map((imgUrl) => (
               <div key={imgUrl}>
-                <Image src={createImageUrl(imgUrl as string)} fill alt="image" style={{ objectFit: 'cover' }} />
+                <Image src={createImageUrl(imgUrl as string)} fill alt="image" style={{ objectFit: 'contain' }} />
               </div>
             ))}
           </S.ImageWrapper>

--- a/src/components/PostDetail/Content/style.tsx
+++ b/src/components/PostDetail/Content/style.tsx
@@ -219,8 +219,6 @@ export const ImageWrapper = styled.div`
     height: 180px;
 
     border-radius: 8px;
-    background-color: var(--color-secondary-main);
-
     overflow: hidden;
   }
 `;


### PR DESCRIPTION
## What is this PR?🔍

- 모집글 이미지가 과도하게 잘리는 현상 방지 및 배경색 삭제를 위함

## 작업 내용

- 이미지의 objectFit 속성을 contain으로 변경
- 이미지의 background-color 삭제

## 결과 화면

<table>
<tr>
<td>기존</td>
<td>이미지 1개</td>
</tr>
<tr>
<td><img width="606" alt="스크린샷 2023-07-26 오전 4 30 12" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/595d9556-22ee-4989-abab-87e86e7dda79"></td>
<td><img width="602" alt="스크린샷 2023-07-26 오전 4 33 30" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/f3f0400f-e156-49a3-81f9-1b1925c4f6e3"></td>
</tr>
<tr>
<td>이미지 2개</td>
<td>이미지 3개</td>
</tr>
<tr>
<td><img width="607" alt="스크린샷 2023-07-26 오전 4 34 08" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/d2db04a8-454e-4525-9c41-da11b5f44c4f"></td>
<td><img width="608" alt="스크린샷 2023-07-26 오전 4 33 45" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/6916b3ac-b23a-4059-9f1d-dbd670f09b38"></td>
</tr>
</table>






