### PR TITLE
[Feat] :  파트너 목록 페이지 구현

### DIFF
--- a/src/apis/partner.ts
+++ b/src/apis/partner.ts
@@ -3,3 +3,7 @@ import authApi from '@apis/auth';
 export const getTodayPartner = () => {
   return authApi.get('api/partner/today');
 };
+
+export const getPartnerList = () => {
+  return authApi.get('api/partner/history');
+}

--- a/src/components/MyPage/PartnerList/Content/index.tsx
+++ b/src/components/MyPage/PartnerList/Content/index.tsx
@@ -74,4 +74,3 @@ const Content = ({ partnerList }: Props) => {
 };
 
 export default Content;
-//<svg width="55" height="55" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="48" height="48" rx="24" fill="#E5E5E7"></rect><mask id="profilelarge_svg__a" maskUnits="userSpaceOnUse" x="0" y="0" width="48" height="48" style="mask-type: alpha;"><rect width="48" height="48" rx="24" fill="#000C4A"></rect></mask><g mask="url(#profilelarge_svg__a)" fill="#000C4A"><rect x="16" y="12" width="16" height="16" rx="8"></rect><rect x="8" y="30" width="32" height="25" rx="12.5"></rect></g></svg>

--- a/src/components/MyPage/PartnerList/Content/index.tsx
+++ b/src/components/MyPage/PartnerList/Content/index.tsx
@@ -3,7 +3,8 @@ import * as S from './style';
 import SearchIcon from '@assets/icon/search.svg';
 import ProfileIcon from '@assets/icon/profilelarge.svg';
 
-const Content = () => {
+
+const Content = ({partnerList}) => {
   const [searchPartner, setSearchPartner] = useState('');
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -18,21 +19,20 @@ const Content = () => {
       </S.Input>
 
       <S.PartnerList>
-        {Array.from({ length: 10 }, (v, i) => i).map((i) => (
-          <S.Partner key={i}>
+        {partnerList.map((p) => (
+          <S.Partner key={p.id}>
             <ProfileIcon />
 
             <S.PartnerInfo>
               <div>
-                <span>운동광</span>
-                <S.Gender>남성</S.Gender>
+                <span>{p.nickname}</span>
+                <S.Gender>{p.gender}</S.Gender>
               </div>
-              <span>2023.04.12</span>
+              <span>{p.workoutDate}</span>
             </S.PartnerInfo>
 
             <S.ButtonContainer>
               <S.ProfileButton onClick={() => alert('프로필 상세 페이지로 이동')}>프로필 상세</S.ProfileButton>
-              <S.ChattingButton onClick={() => alert('채팅 페이지로 이동')}>채팅하기</S.ChattingButton>
             </S.ButtonContainer>
           </S.Partner>
         ))}

--- a/src/components/MyPage/PartnerList/Content/index.tsx
+++ b/src/components/MyPage/PartnerList/Content/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import * as S from './style';
 import SearchIcon from '@assets/icon/search.svg';
 import ProfileIcon from '@assets/icon/profilelarge.svg';
@@ -6,10 +6,22 @@ import ProfileIcon from '@assets/icon/profilelarge.svg';
 
 const Content = ({partnerList}) => {
   const [searchPartner, setSearchPartner] = useState('');
+  const [filteredPartnerList, setFilteredPartnerList] = useState<PartnerListType[]>(partnerList);
 
   const handleChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchPartner(e.target.value);
   };
+
+  const executeSearch = () => {
+    const filteredList = partnerList.filter((partner) => {
+      return partner.nickname.toLowerCase().includes(searchPartner.toLowerCase());
+    });
+    setFilteredPartnerList(filteredList);
+  }
+
+  useEffect(() => {
+    executeSearch();
+  }, [searchPartner]);
 
   return (
     <S.Wrapper>
@@ -19,7 +31,7 @@ const Content = ({partnerList}) => {
       </S.Input>
 
       <S.PartnerList>
-        {partnerList.map((p) => (
+        {filteredPartnerList.map((p) => (
           <S.Partner key={p.id}>
             <ProfileIcon />
 

--- a/src/components/MyPage/PartnerList/Content/index.tsx
+++ b/src/components/MyPage/PartnerList/Content/index.tsx
@@ -13,6 +13,10 @@ const Content = ({partnerList}) => {
   };
 
   const executeSearch = () => {
+    if (searchPartner.trim() === '') {
+      setFilteredPartnerList(partnerList); // 검색어가 없는 경우, 전체 파트너 목록을 보여줍니다.
+      return;
+    }
     const filteredList = partnerList.filter((partner) => {
       return partner.nickname.toLowerCase().includes(searchPartner.toLowerCase());
     });
@@ -22,6 +26,10 @@ const Content = ({partnerList}) => {
   useEffect(() => {
     executeSearch();
   }, [searchPartner]);
+
+  useEffect(() => {
+    setFilteredPartnerList(partnerList);
+  }, [partnerList]);
 
   return (
     <S.Wrapper>

--- a/src/components/MyPage/PartnerList/Content/index.tsx
+++ b/src/components/MyPage/PartnerList/Content/index.tsx
@@ -1,10 +1,16 @@
 import { useState, useEffect } from 'react';
 import * as S from './style';
 import SearchIcon from '@assets/icon/search.svg';
-import ProfileIcon from '@assets/icon/profilelarge.svg';
 import { useRouter } from 'next/router';
+import { PartnerListType } from '@typing/Partner';
+import { createImageUrl } from '@utils/createImageUrl';
+import ProfileIcon from '@assets/icon/profilelarge.svg';
 
-const Content = ({partnerList}) => {
+interface Props {
+  partnerList: PartnerListType[];
+}
+
+const Content = ({ partnerList }: Props) => {
   const router = useRouter();
   const [searchPartner, setSearchPartner] = useState('');
   const [filteredPartnerList, setFilteredPartnerList] = useState<PartnerListType[]>(partnerList);
@@ -22,7 +28,7 @@ const Content = ({partnerList}) => {
       return partner.nickname.toLowerCase().includes(searchPartner.toLowerCase());
     });
     setFilteredPartnerList(filteredList);
-  }
+  };
 
   useEffect(() => {
     executeSearch();
@@ -41,8 +47,13 @@ const Content = ({partnerList}) => {
       <S.PartnerList>
         {filteredPartnerList.map((p) => (
           <S.Partner key={p.id}>
-            <S.ProfileButton>
-              <ProfileIcon onClick={() => {router.push(`/mypage/${p.id}`);}} />
+            <S.ProfileButton onClick={() => {router.push(`/mypage/${p.id}`);}}>
+              {p.profileUrl ? (
+                <S.ImageWrapper>
+                  <img src={createImageUrl(p.profileUrl as string)} alt='profileImg'/>
+                </S.ImageWrapper> ) :(
+                <ProfileIcon/>
+              )}
             </S.ProfileButton>
             <S.PartnerInfo>
               <div>
@@ -59,3 +70,4 @@ const Content = ({partnerList}) => {
 };
 
 export default Content;
+//<svg width="55" height="55" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg"><rect width="48" height="48" rx="24" fill="#E5E5E7"></rect><mask id="profilelarge_svg__a" maskUnits="userSpaceOnUse" x="0" y="0" width="48" height="48" style="mask-type: alpha;"><rect width="48" height="48" rx="24" fill="#000C4A"></rect></mask><g mask="url(#profilelarge_svg__a)" fill="#000C4A"><rect x="16" y="12" width="16" height="16" rx="8"></rect><rect x="8" y="30" width="32" height="25" rx="12.5"></rect></g></svg>

--- a/src/components/MyPage/PartnerList/Content/index.tsx
+++ b/src/components/MyPage/PartnerList/Content/index.tsx
@@ -2,9 +2,10 @@ import { useState, useEffect } from 'react';
 import * as S from './style';
 import SearchIcon from '@assets/icon/search.svg';
 import ProfileIcon from '@assets/icon/profilelarge.svg';
-
+import { useRouter } from 'next/router';
 
 const Content = ({partnerList}) => {
+  const router = useRouter();
   const [searchPartner, setSearchPartner] = useState('');
   const [filteredPartnerList, setFilteredPartnerList] = useState<PartnerListType[]>(partnerList);
 
@@ -37,12 +38,12 @@ const Content = ({partnerList}) => {
         <SearchIcon />
         <input value={searchPartner} onChange={handleChangeInput} placeholder="파트너를 검색해보세요." />
       </S.Input>
-
       <S.PartnerList>
         {filteredPartnerList.map((p) => (
           <S.Partner key={p.id}>
-            <ProfileIcon />
-
+            <S.ProfileButton>
+              <ProfileIcon onClick={() => {router.push(`/mypage/${p.id}`);}} />
+            </S.ProfileButton>
             <S.PartnerInfo>
               <div>
                 <span>{p.nickname}</span>
@@ -50,10 +51,6 @@ const Content = ({partnerList}) => {
               </div>
               <span>{p.workoutDate}</span>
             </S.PartnerInfo>
-
-            <S.ButtonContainer>
-              <S.ProfileButton onClick={() => alert('프로필 상세 페이지로 이동')}>프로필 상세</S.ProfileButton>
-            </S.ButtonContainer>
           </S.Partner>
         ))}
       </S.PartnerList>

--- a/src/components/MyPage/PartnerList/Content/index.tsx
+++ b/src/components/MyPage/PartnerList/Content/index.tsx
@@ -45,25 +45,29 @@ const Content = ({ partnerList }: Props) => {
         <input value={searchPartner} onChange={handleChangeInput} placeholder="파트너를 검색해보세요." />
       </S.Input>
       <S.PartnerList>
-        {filteredPartnerList.map((p) => (
-          <S.Partner key={p.id}>
-            <S.ProfileButton onClick={() => {router.push(`/mypage/${p.id}`);}}>
-              {p.profileUrl ? (
-                <S.ImageWrapper>
-                  <img src={createImageUrl(p.profileUrl as string)} alt='profileImg'/>
-                </S.ImageWrapper> ) :(
-                <ProfileIcon/>
-              )}
-            </S.ProfileButton>
-            <S.PartnerInfo>
-              <div>
-                <span>{p.nickname}</span>
-                <S.Gender>{p.gender}</S.Gender>
-              </div>
-              <span>{p.workoutDate}</span>
-            </S.PartnerInfo>
-          </S.Partner>
-        ))}
+        {filteredPartnerList !== undefined ? (
+          filteredPartnerList.map((p) => (
+            <S.Partner key={p.id}>
+              <S.ProfileButton onClick={() => {router.push(`/mypage/${p.id}`);}}>
+                {p.profileUrl ? (
+                  <S.ImageWrapper>
+                    <img src={createImageUrl(p.profileUrl as string)} alt='profileImg'/>
+                  </S.ImageWrapper> ) :(
+                  <ProfileIcon/>
+                )}
+              </S.ProfileButton>
+              <S.PartnerInfo>
+                <div>
+                  <span>{p.nickname}</span>
+                  <S.Gender>{p.gender}</S.Gender>
+                </div>
+                <span>{p.workoutDate}</span>
+              </S.PartnerInfo>
+            </S.Partner>
+          ))
+        ) : (
+          <S.NoPartner>운동 파트너가 존재하지 않습니다.</S.NoPartner>
+        )}
       </S.PartnerList>
     </S.Wrapper>
   );

--- a/src/components/MyPage/PartnerList/Content/style.tsx
+++ b/src/components/MyPage/PartnerList/Content/style.tsx
@@ -79,7 +79,6 @@ export const ImageWrapper = styled.div`
   img {
     width: 100%;
     height: 100%;
-    border-radius: 2164.5px;
   }
 `;
 
@@ -123,7 +122,7 @@ export const ButtonContainer = styled.div`
 
 const Button = styled.button`
   width: 106px;
-  padding: 10px 10px;
+  padding: 10px;
 
   border: none;
   border-radius: 6px;

--- a/src/components/MyPage/PartnerList/Content/style.tsx
+++ b/src/components/MyPage/PartnerList/Content/style.tsx
@@ -41,6 +41,7 @@ export const PartnerList = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
+  min-height: calc(100vh - 60px - 190px);
 `;
 
 export const Partner = styled.div`

--- a/src/components/MyPage/PartnerList/Content/style.tsx
+++ b/src/components/MyPage/PartnerList/Content/style.tsx
@@ -63,6 +63,12 @@ export const Partner = styled.div`
   }
 `;
 
+export const NoPartner = styled.div`
+  margin: auto;
+  font-size: 20px;
+  font-weight: bold;
+`;
+
 export const ImageWrapper = styled.div`
   width: 80px;
   height: 80px;

--- a/src/components/MyPage/PartnerList/Content/style.tsx
+++ b/src/components/MyPage/PartnerList/Content/style.tsx
@@ -122,8 +122,7 @@ const Button = styled.button`
 `;
 
 export const ProfileButton = styled(Button)`
-  background-color: var(--color-primary-main);
-  color: var(--color-white);
+  background-color: transparent;
 `;
 
 export const ChattingButton = styled(Button)`

--- a/src/components/MyPage/PartnerList/Content/style.tsx
+++ b/src/components/MyPage/PartnerList/Content/style.tsx
@@ -69,6 +69,12 @@ export const ImageWrapper = styled.div`
   border-radius: 50%;
   background-color: var(--color-secondary-main);
   overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    border-radius: 2164.5px;
+  }
 `;
 
 export const PartnerInfo = styled.div`
@@ -111,7 +117,7 @@ export const ButtonContainer = styled.div`
 
 const Button = styled.button`
   width: 106px;
-  padding: 10px 0;
+  padding: 10px 10px;
 
   border: none;
   border-radius: 6px;

--- a/src/hooks/MyPage/queries/index.ts
+++ b/src/hooks/MyPage/queries/index.ts
@@ -1,2 +1,3 @@
 export { default as useGetMyProfile } from './useGetMyProfile';
 export { default as useGetOtherProfile } from './useGetOtherProfile';
+export { default as useGetPartnerList } from './useGetPartnerList';

--- a/src/hooks/MyPage/queries/useGetPartnerList.ts
+++ b/src/hooks/MyPage/queries/useGetPartnerList.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@constants/querykeys';
+import { getPartnerList } from '@apis/partner';
+
+const useGetPartnerList = () => {
+    const queryResult = useQuery(queryKeys.partner, () => getPartnerList());
+
+    return {
+        data: queryResult.data,
+        isLoading: queryResult.isLoading,
+        refetch: queryResult.refetch,
+    };
+};
+
+export default useGetPartnerList;

--- a/src/hooks/MyPage/queries/useGetPartnerList.ts
+++ b/src/hooks/MyPage/queries/useGetPartnerList.ts
@@ -7,7 +7,7 @@ const useGetPartnerList = () => {
 
     return {
         data: queryResult.data,
-        isLoading: queryResult.isLoading,
+        isError: queryResult.isError,
         refetch: queryResult.refetch,
     };
 };

--- a/src/pages/mypage/[memberId].tsx
+++ b/src/pages/mypage/[memberId].tsx
@@ -17,7 +17,7 @@ const OtherPage = () => {
     if (memberId) setMemberId(memberId as string);
   }, [router.query]);
 
-  if (isLoading) {
+  if (isLoading || !memberId) {
     return <Loader />;
   }
 

--- a/src/pages/mypage/partners/index.tsx
+++ b/src/pages/mypage/partners/index.tsx
@@ -1,26 +1,22 @@
 import { Content, Header } from '@components/MyPage/PartnerList';
-import { useEffect, useState } from 'react';
-import { getPartnerList } from '@apis/partner';
+import { useGetPartnerList } from '@hooks/MyPage/queries';
 import { Navigation } from '@components/Common';
+import { Loader } from '@components/Common';
 
 const PartnerList = () => {
-  const [partnerList, setPartnerList] = useState([]);
+  const { data: partnerListData, isLoading, refetch } = useGetPartnerList();
 
-  useEffect(() => {
-    getPartnerList()
-      .then((res) => {
-        console.log(res.data);
-        setPartnerList(res.data);
-      })
-      .catch((error) => {
-        console.log(error);
-      });
-  }, []);
+  if (isLoading || !partnerListData) {
+    if (!partnerListData) {
+      refetch();
+    }
+    return <Loader />;
+  }
 
   return (
     <>
       <Header />
-      <Content partnerList={partnerList} />
+      <Content partnerList={partnerListData.data} />
       <Navigation />
     </>
   );

--- a/src/pages/mypage/partners/index.tsx
+++ b/src/pages/mypage/partners/index.tsx
@@ -1,20 +1,30 @@
 import { Content, Header } from '@components/MyPage/PartnerList';
-import { NextPageWithLayout } from '@pages/_app';
-import React, { ReactElement } from 'react';
+import { useEffect, useState } from 'react';
+import { getPartnerList } from '@apis/partner';
 
-const PartnerList: NextPageWithLayout = () => {
-  return (
-    <>
-      <Content />
-    </>
-  );
-};
 
-PartnerList.getLayout = function getLayout(page: ReactElement) {
+
+const PartnerList = () => {
+  const [partnerList, setPartnerList] = useState([]);
+
+  useEffect(() => {
+    getPartnerList()
+      .then((res) => {
+        console.log(res.data);
+        setPartnerList(res.data);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  }, []);
+
+
+
+
   return (
     <>
       <Header />
-      {page}
+      <Content partnerList={partnerList} />
     </>
   );
 };

--- a/src/pages/mypage/partners/index.tsx
+++ b/src/pages/mypage/partners/index.tsx
@@ -2,21 +2,34 @@ import { Content, Header } from '@components/MyPage/PartnerList';
 import { useGetPartnerList } from '@hooks/MyPage/queries';
 import { Navigation } from '@components/Common';
 import { Loader } from '@components/Common';
+import { useEffect, useState } from 'react';
 
 const PartnerList = () => {
-  const { data: partnerListData, isLoading, refetch } = useGetPartnerList();
-
-  if (isLoading || !partnerListData) {
-    if (!partnerListData) {
+  const { data: partnerListData, isError, refetch } = useGetPartnerList();
+  const [isPossibleToRendering, setIsPossibleToRendering] = useState(false);
+  
+  useEffect(() => {
+    if (isError) {
+      setIsPossibleToRendering(true);
+    }
+    if (partnerListData) {
+      setIsPossibleToRendering(true);
+    } 
+    if (!isPossibleToRendering) {
       refetch();
     }
+  }, [isError, partnerListData, isPossibleToRendering, refetch]);
+
+  if (!isPossibleToRendering) {
     return <Loader />;
   }
+
+  const partners = partnerListData?.data;
 
   return (
     <>
       <Header />
-      <Content partnerList={partnerListData.data} />
+      <Content partnerList={partners} />
       <Navigation />
     </>
   );

--- a/src/pages/mypage/partners/index.tsx
+++ b/src/pages/mypage/partners/index.tsx
@@ -1,8 +1,7 @@
 import { Content, Header } from '@components/MyPage/PartnerList';
 import { useEffect, useState } from 'react';
 import { getPartnerList } from '@apis/partner';
-
-
+import { Navigation } from '@components/Common';
 
 const PartnerList = () => {
   const [partnerList, setPartnerList] = useState([]);
@@ -18,13 +17,11 @@ const PartnerList = () => {
       });
   }, []);
 
-
-
-
   return (
     <>
       <Header />
       <Content partnerList={partnerList} />
+      <Navigation />
     </>
   );
 };

--- a/src/typing/Partner.ts
+++ b/src/typing/Partner.ts
@@ -1,0 +1,7 @@
+export interface PartnerListType {
+    id: number;
+    nickname: string;
+    profileUrl: string;
+    gender: '남성' | '여성';
+    workoutDate: string;
+}


### PR DESCRIPTION
##  What is this PR?🔍

파트너 목록 페이지를 구현하였습니다 

 <br/>

##  ✅ 작업 내용 리스트
- [x] 채팅하기 버튼 없애기
- [x] 파트너 목록 API 작업
- [x] 파트너 검색 로직 구현
- [x] 바텀시트에 네비바 추가하기
- [x] 프로필 상세 이동 기능 구현
- [x] 프로필 상세 버튼 제거, 프로필 이미지에 버튼 추가
- [x] content 갯수에 상관없이 전체 페이지 길이 유지하도록 구현하기
- [x] api 호출 리액트 쿼리 사용하는 방식으로 변경하기
- [x] 파트너 목록이 없을 경우 예외 처리

<br/>

## 🖥️ 스크린샷 및 영상
### 파트너 목록이 존재할 경우
https://github.com/Sinchone/LastOne-FrontEnd/assets/96610382/37a64bd2-8fa2-41d1-8e58-831f23a2a9a0

<br/>

### 파트너 목록이 없을 경우
https://github.com/Sinchone/LastOne-FrontEnd/assets/96610382/a0acc064-e3e4-4981-b4eb-393cf9d33a82



