### PR TITLE
[Feat]: 글쓰기 페이지 이미지 다중 업로드 구현

### DIFF
--- a/src/components/PostWrite/Content/index.tsx
+++ b/src/components/PostWrite/Content/index.tsx
@@ -17,6 +17,7 @@ import { checkAllKeysHaveValues } from '@utils/checkAllKeysHaveValues';
 import { Map } from '@components/Common';
 import Images from '../Image';
 import { useRouter } from 'next/router';
+import NoImage from '../Image/None';
 
 const Content = () => {
   const initialData: Post = {
@@ -40,8 +41,7 @@ const Content = () => {
   const selectedDate = useRecoilValue(selectedDateState);
   const selectedTime = useRecoilValue(selectedTimeState);
   const [isMapShow, setIsMapShow] = useRecoilState(isMapShowState);
-  const [showImages, setShowImages] = useState<any>('');
-  const [imgFiles, setImgFiles] = useState<any>('');
+  const [imgFiles, setImgFiles] = useState<any>([]);
   const inputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { showBottomSheet } = useBottomSheet();
@@ -138,6 +138,8 @@ const Content = () => {
     router.reload();
   };
 
+  console.log('imgFiles:', imgFiles);
+
   return (
     <>
       {!isMapShow ? (
@@ -224,7 +226,12 @@ const Content = () => {
           {/* 상세설명 */}
           <S.DescriptionArea>
             <S.Subject>상세설명</S.Subject>
-            <Images setImgFiles={setImgFiles} />
+            {imgFiles.join('') ? (
+              <Images setImgFiles={setImgFiles} imgFiles={imgFiles} />
+            ) : (
+              <NoImage setImgFiles={setImgFiles} />
+            )}
+
             <S.DescriptionTextAreaWrapper>
               <span>{data.description.length}/100</span>
               <textarea

--- a/src/components/PostWrite/Image/None/index.tsx
+++ b/src/components/PostWrite/Image/None/index.tsx
@@ -1,7 +1,25 @@
 import * as S from './style';
 import AddImgIcon from '@assets/icon/addImg.svg';
 
-const NoImage = () => {
+interface Props {
+  setImgFiles: React.Dispatch<React.SetStateAction<string[]>>;
+}
+
+const NoImage = ({ setImgFiles }: Props) => {
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files as any;
+    const maxLength = files.length > 3 ? 3 : files.length;
+    const images: string[] = [];
+
+    if (files.length > 3) alert('최대 3장까지 첨부할 수 있습니다.');
+
+    for (let i = 0; i < maxLength; i++) {
+      images.push(files[i]);
+    }
+
+    setImgFiles(images);
+  };
+
   return (
     <S.Wrapper>
       <label htmlFor="image-input">
@@ -11,11 +29,10 @@ const NoImage = () => {
           name="image"
           multiple
           accept=".gif, .jpg, .png, .jpeg"
-          // onChange={handleImageChange}
+          onChange={handleImageChange}
         />
+        <AddImgIcon />
       </label>
-      <AddImgIcon />
-      <div></div>
       <div>
         <S.Image></S.Image>
         <S.Image></S.Image>

--- a/src/components/PostWrite/Image/None/style.tsx
+++ b/src/components/PostWrite/Image/None/style.tsx
@@ -12,18 +12,27 @@ export const Wrapper = styled.div`
   overflow: hidden;
   position: relative;
 
-  & svg {
-    z-index: 2;
-    position: absolute;
-  }
-
-  > div:first-of-type {
+  label {
     width: 100%;
     height: 180px;
     background-color: rgba(0, 0, 0, 0.2);
     position: absolute;
+    cursor: pointer;
+
+    svg {
+      z-index: 2;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
   }
-  > div:nth-of-type(2) {
+
+  input {
+    visibility: hidden;
+  }
+
+  > div {
     width: 100%;
     height: 100%;
     display: flex;

--- a/src/components/PostWrite/Image/Select/index.tsx
+++ b/src/components/PostWrite/Image/Select/index.tsx
@@ -11,7 +11,8 @@ interface Props {
 }
 
 const SelectImage = ({ onChange, onDelete, image, index }: Props) => {
-  const [showImage, setShowImage] = useState<any>('');
+  const uploadedImageURL = image && URL.createObjectURL(image as any);
+  const [showImage, setShowImage] = useState<any>(uploadedImageURL);
 
   const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] as any;

--- a/src/components/PostWrite/Image/index.tsx
+++ b/src/components/PostWrite/Image/index.tsx
@@ -3,11 +3,12 @@ import SelectImage from './Select';
 import { useEffect, useState } from 'react';
 
 interface Props {
+  imgFiles: string[];
   setImgFiles: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-const Image = ({ setImgFiles }: Props) => {
-  const [images, setImages] = useState(['', '', '']);
+const Image = ({ imgFiles, setImgFiles }: Props) => {
+  const [images, setImages] = useState(imgFiles);
 
   const handleChange = (index: number, image: string) => {
     const newImages = [...images];


### PR DESCRIPTION
## What is this PR?🔍

글쓰기 api 완성(성별, 이미지 기능 추가)

## 작업 사항 💪🏻

- feat: 게시글 작성 페이지에서 성별 선택 기능과 개별 이미지 업로드 기능을 추가했습니다.
  - 개별 이미지 업로드 및 삭제 가능
- refactor: 기존에 작성했던 이미지 업로드 부분 코드를 컴포넌트로 만들어 분리했습니다.

**주요 커밋**
- [성별 선택 기능 추가](https://github.com/Sinchone/LastOne-FrontEnd/commit/72c14effe1732e32006315cdb44029b95f3b35b8)
- [개별 이미지 업로드 기능 추가](https://github.com/Sinchone/LastOne-FrontEnd/commit/add1c8fdde74277a4fa7a1d57bc33c00e21a864b)
- [이미지 등록 컴포넌트 작성](https://github.com/Sinchone/LastOne-FrontEnd/commit/06e7c6f40269710085fa5cb1c16bcadd9fee0d48)
- [이미지 등록 부분 컴포넌트화](https://github.com/Sinchone/LastOne-FrontEnd/commit/4426cc9f872845414182bda5050d3ce523a82f34)


## 🖥️ 스크린샷 및 영상

https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/65afa5f3-b2a7-45dc-964d-80daa2e4ceb6

⚠️ 첨부 가능한 용량 제한으로 인해 캡쳐 영상의 화질을 낮췄습니다.

- 개별 이미지 업로드

  https://github.com/Sinchone/LastOne-FrontEnd/assets/87893624/c72997f0-e498-4fb7-8db5-97db2d470d94

- 다중 이미지 업로드

  https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/8421ebe9-654b-45ce-ab06-fe522f46a211



