### PR TITLE
[Design] Navigation 바의 a 태그 너비 확장

### DIFF
--- a/src/components/Common/Navigation/style.tsx
+++ b/src/components/Common/Navigation/style.tsx
@@ -28,6 +28,10 @@ export const NavList = styled.ul`
   justify-content: space-around;
   align-items: center;
   width: 100%;
+
+  a {
+    width: 25%;
+  }
 `;
 export const HomeNav = styled.li<{ isLocated: boolean }>`
   display: flex;


### PR DESCRIPTION
## What is this PR?🔍

- 네비게이션 바의 각 메뉴 너비 확장

## 화면

> 이미지에서 하이라이트 된 부분이 모두 터치/클릭 가능 영역입니다.

<img width="359" alt="스크린샷 2023-09-02 오후 11 20 24" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/606aa4d7-9703-45b4-bcba-3f33a538abb3">

