### PR TITLE
[Feat]: 운동 날짜와 시간 선택할 때 현재 날짜와 시간 받아와서 이전 날짜와 시간은 선택 못하도록 구현

### DIFF
--- a/src/components/Common/BottomSheet/BottomSheetList/Calendar/index.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/Calendar/index.tsx
@@ -66,6 +66,7 @@ const Calendar = () => {
             onChange={handleDateChange as any}
             value={selectedDate}
             calendarType={'gregory'}
+            minDate={new Date()}
             formatMonthYear={(locale, date) => moment(date).format('YYYY.MM')}
             formatDay={(locale, date) => moment(date).format('D')}
           />

--- a/src/components/Common/BottomSheet/BottomSheetList/Calendar/style.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/Calendar/style.tsx
@@ -115,6 +115,7 @@ export const CalendarWrapper = styled.div`
     width: 100%;
     border: none;
     padding-bottom: 10px;
+    background: none;
     .react-calendar__navigation {
       justify-content: center;
       align-items: center;
@@ -123,10 +124,10 @@ export const CalendarWrapper = styled.div`
       margin-bottom: 25px;
       align-items: center;
       &:hover {
-        background-color: var(--color-white);
+        background: none;
       }
       button {
-        background-color: var(--color-white);
+        background: none;
       }
     }
 
@@ -138,7 +139,7 @@ export const CalendarWrapper = styled.div`
     }
     .react-calendar__navigation__label {
       &:hover {
-        background-color: var(--color-white);
+        background: none;
       }
     }
 
@@ -169,6 +170,11 @@ export const CalendarWrapper = styled.div`
       font-family: 'Pretendard';
       font-weight: 400;
       min-width: 497px;
+
+      abbr {
+        text-decoration: none;
+        user-select: none;
+      }
     }
 
     .react-calendar__month-view__days {
@@ -211,6 +217,11 @@ export const CalendarWrapper = styled.div`
 
     .react-calendar__tile:enabled:focus {
       background-color: white;
+    }
+
+    .react-calendar__tile:disabled {
+      color: var(--color-gray5) !important;
+      background: none;
     }
   }
 `;

--- a/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/Time/index.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/Time/index.tsx
@@ -1,6 +1,7 @@
 import * as S from './style';
 import { TimeType } from '@typing/post';
 import { times } from '@constants/post';
+import { calHour } from '@utils/calDate';
 
 type TimeProps = {
   onChange: ({ meridiem, time }: TimeType) => void;
@@ -8,6 +9,20 @@ type TimeProps = {
 };
 
 const Time = ({ onChange, currentTime }: TimeProps) => {
+  const now = calHour(new Date().getHours());
+
+  const checkIsPast = ({ meridiem, time }: TimeType) => {
+    const hour = +time.split(':')[0];
+
+    if (meridiem === '오전') {
+      if (now.meridiem === '오후' || (hour === 12 ? 0 : hour) <= now.time) return true;
+      return false;
+    }
+
+    if (now.meridiem === '오후' && (hour === 12 ? 0 : hour) <= now.time) return true;
+    return false;
+  };
+
   return (
     <div>
       <S.Wrapper>
@@ -17,9 +32,10 @@ const Time = ({ onChange, currentTime }: TimeProps) => {
             <S.Time
               key={idx}
               onClick={() => {
-                onChange({ meridiem: '오전', time });
+                !checkIsPast({ meridiem: '오전', time }) && onChange({ meridiem: '오전', time });
               }}
               isSelected={time === (currentTime.meridiem === '오전' && currentTime.time)}
+              isDisabled={checkIsPast({ meridiem: '오전', time })}
             >
               {time}
             </S.Time>
@@ -33,9 +49,10 @@ const Time = ({ onChange, currentTime }: TimeProps) => {
             <S.Time
               key={idx}
               onClick={() => {
-                onChange({ meridiem: '오후', time });
+                !checkIsPast({ meridiem: '오후', time }) && onChange({ meridiem: '오후', time });
               }}
               isSelected={time === (currentTime.meridiem === '오후' && currentTime.time)}
+              isDisabled={checkIsPast({ meridiem: '오후', time })}
             >
               {time}
             </S.Time>

--- a/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/Time/style.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/Time/style.tsx
@@ -20,7 +20,23 @@ export const TimesWrapper = styled.div`
   margin-bottom: 24px;
 `;
 
-export const Time = styled.div<{ isSelected: boolean }>`
+const disabled = `
+  cursor: default;
+  background-color: var(--color-gray2);
+  color: var(--color-gray5);
+`;
+
+const selected = `
+  background-color: var(--color-primary-main);
+  color: var(--color-white);
+`;
+
+const normal = `
+  background-color: var(--color-white);
+  color: var(--color-gray8);
+`;
+
+export const Time = styled.div<{ isSelected: boolean; isDisabled: boolean }>`
   width: 12%;
   height: 54px;
   display: flex;
@@ -30,6 +46,10 @@ export const Time = styled.div<{ isSelected: boolean }>`
   border-radius: 8px;
   cursor: pointer;
   font-weight: 400;
-  background-color: ${(props) => (props.isSelected ? 'var(--color-primary-main)' : 'var(--color-white)')};
-  color: ${(props) => (props.isSelected ? 'var(--color-white)' : 'var(--color-gray8)')};
+  user-select: none;
+  background-color: var(--color-white);
+  color: var(--color-gray8);
+
+  ${(props) => (props.isSelected ? selected : normal)}
+  ${(props) => props.isDisabled && disabled}
 `;

--- a/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/index.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/index.tsx
@@ -58,6 +58,7 @@ const CalendarTime = ({ initialMenu = 'calendar' }: Props) => {
               onChange={handleDateChange as any}
               value={selectedDate}
               calendarType={'gregory'}
+              minDate={new Date()}
               formatMonthYear={(locale, date) => moment(date).format('YYYY.MM')}
               formatDay={(locale, date) => moment(date).format('D')}
             />

--- a/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/style.tsx
+++ b/src/components/Common/BottomSheet/BottomSheetList/CalendarTime/style.tsx
@@ -113,16 +113,17 @@ export const CalendarWrapper = styled.div`
     width: 100%;
     border: none;
     padding-bottom: 10px;
+    background: none;
     .react-calendar__navigation {
       width: 200px;
       margin: 0 auto;
       margin-bottom: 25px;
       align-items: center;
       &:hover {
-        background-color: var(--color-white);
+        background: none;
       }
       button {
-        background-color: var(--color-white);
+        background: none;
       }
     }
 
@@ -134,7 +135,7 @@ export const CalendarWrapper = styled.div`
     }
     .react-calendar__navigation__label {
       &:hover {
-        background-color: var(--color-white);
+        background: none;
       }
     }
 
@@ -165,6 +166,11 @@ export const CalendarWrapper = styled.div`
       font-family: 'Pretendard';
       font-weight: 400;
       min-width: 497px;
+
+      abbr {
+        text-decoration: none;
+        user-select: none;
+      }
     }
 
     .react-calendar__month-view__days {
@@ -206,6 +212,10 @@ export const CalendarWrapper = styled.div`
     }
     .react-calendar__tile:enabled:focus {
       background-color: white;
+    }
+    .react-calendar__tile:disabled {
+      color: var(--color-gray5) !important;
+      background: none;
     }
   }
 `;

--- a/src/utils/calDate.ts
+++ b/src/utils/calDate.ts
@@ -32,3 +32,16 @@ export const calDateForMessage = (input: string) => {
 
   return `${period} ${convertedHour}:${minute}`;
 };
+
+export const calHour = (hour: number) => {
+  if (hour < 12) {
+    return {
+      meridiem: '오전',
+      time: hour,
+    };
+  }
+  return {
+    meridiem: '오후',
+    time: hour - 12,
+  };
+};


### PR DESCRIPTION
## What is this PR?🔍

- 바텀 시트(Calendar, CalendarTime)
  - 캘린더: 이미 지난 날짜는 선택할 수 없도록 수정
  - 시간: 이미 지난 시간은 선택할 수 없도록 수정

## 화면

- 캘린더
  <img width="610" alt="스크린샷 2023-09-03 오전 12 45 21" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/4e0600e0-961c-4f56-a57f-3a6580f544d1">
- 시간
  <img width="607" alt="스크린샷 2023-09-03 오전 12 45 11" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/aa131a49-29fd-4722-a7cb-1ddcb977bfa2">



