### PR TITLE
[Design]: 모달 백그라운드 영역 조정

### DIFF
--- a/src/components/Common/ModalLayout/style.tsx
+++ b/src/components/Common/ModalLayout/style.tsx
@@ -17,8 +17,8 @@ export const Overlay = styled.div`
   left: 0;
   top: 0;
   z-index: 20;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   cursor: pointer;
   background-color: var(--color-black);
 


### PR DESCRIPTION
## What is this PR?🔍

- 모바일 뷰에서 모달 백그라운드가 전체 화면을 가릴 수 있도록 수정

## 화면

<table>
<tr>
<td><img width="438" alt="스크린샷 2023-09-03 오전 1 22 54" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/efb31397-5a40-46cb-bd5b-7ac333f0bf08"></td>
<td><img width="503" alt="스크린샷 2023-09-03 오전 1 23 12" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/b5118cd5-96e5-4f0c-a20f-48c6977bc90e"></td>
</tr>
</table>


