### PR TITLE
[Design]: 모집글 상세 페이지의 좌우 여백을 작성 페이지와 통일

### DIFF
--- a/src/components/PostDetail/Content/style.tsx
+++ b/src/components/PostDetail/Content/style.tsx
@@ -3,7 +3,7 @@ import styled from 'styled-components';
 export const Wrapper = styled.main`
   width: 100%;
   height: fit-content;
-  padding: 30px 15px 50px 15px;
+  padding: 30px 24px 50px 24px;
 `;
 
 export const WriterWrapper = styled.div``;


### PR DESCRIPTION
## What is this PR?🔍

- 모집글 상세 페이지의 좌우 여백을 작성 페이지와 통일

## 화면

<table>
<tr>
<td>Before</td>
<td>After</td>
</tr>
<tr>
<td><img width="637" alt="스크린샷 2023-09-19 오후 5 15 25" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/044cac22-1283-4dc2-b84b-d8ff394a9c9c"></td>
<td><img width="631" alt="스크린샷 2023-09-19 오후 5 15 37" src="https://github.com/Sinchone/LastOne-FrontEnd/assets/51291185/fc12e959-b850-451a-b6f3-401133c50964"></td>
</tr>
</table>


